### PR TITLE
feat: add React-based project management mock UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FlowTask Manager</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "flowtask",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,420 @@
+import { useMemo, useState } from 'react';
+import ModuleView from './components/ModuleView.jsx';
+
+const PRIORITIES = ['低', '中', '高'];
+const STATUSES = ['未开始', '进行中', '已完成'];
+
+const createId = () => Math.random().toString(36).slice(2, 10);
+
+export default function App() {
+  const [stages, setStages] = useState([
+    { id: 'stage-plan', name: '规划' },
+    { id: 'stage-build', name: '开发' },
+    { id: 'stage-review', name: '验收' }
+  ]);
+
+  const [taskTypes, setTaskTypes] = useState([
+    { id: 'type-feature', name: '功能' },
+    { id: 'type-bug', name: '缺陷修复' },
+    { id: 'type-doc', name: '文档' }
+  ]);
+
+  const [workflows, setWorkflows] = useState([
+    {
+      id: 'workflow-default',
+      name: '标准产品流程',
+      stageIds: ['stage-plan', 'stage-build', 'stage-review'],
+      taskTypeIds: ['type-feature', 'type-bug', 'type-doc']
+    }
+  ]);
+
+  const [projects, setProjects] = useState([
+    { id: 'project-alpha', name: 'Alpha 项目', workflowId: 'workflow-default' }
+  ]);
+
+  const [modules, setModules] = useState([
+    { id: 'module-alpha-core', projectId: 'project-alpha', name: '核心模块', workflowId: null },
+    { id: 'module-alpha-mobile', projectId: 'project-alpha', name: '移动端', workflowId: 'workflow-default' }
+  ]);
+
+  const [tasks, setTasks] = useState([
+    {
+      id: 'task-1',
+      moduleId: 'module-alpha-core',
+      stageId: 'stage-plan',
+      taskTypeId: 'type-feature',
+      name: '需求梳理',
+      description: '梳理 MVP 范围',
+      priority: '高',
+      status: '进行中',
+      startDate: '2024-06-01',
+      endDate: '2024-06-07',
+      parentTaskId: null
+    },
+    {
+      id: 'task-1-1',
+      moduleId: 'module-alpha-core',
+      stageId: 'stage-plan',
+      taskTypeId: 'type-doc',
+      name: 'PRD 草稿',
+      description: '完成初版 PRD 文档',
+      priority: '中',
+      status: '未开始',
+      startDate: '',
+      endDate: '',
+      parentTaskId: 'task-1'
+    }
+  ]);
+
+  const [stageName, setStageName] = useState('');
+  const [taskTypeName, setTaskTypeName] = useState('');
+  const [workflowForm, setWorkflowForm] = useState({
+    name: '',
+    stageIds: ['stage-plan', 'stage-build'],
+    taskTypeIds: ['type-feature']
+  });
+
+  const [projectForm, setProjectForm] = useState({
+    name: '',
+    workflowId: 'workflow-default'
+  });
+
+  const [moduleForm, setModuleForm] = useState({
+    projectId: 'project-alpha',
+    name: '',
+    workflowId: 'workflow-default'
+  });
+
+  const [selectedProjectId, setSelectedProjectId] = useState('project-alpha');
+  const [selectedModuleId, setSelectedModuleId] = useState('module-alpha-core');
+
+  const selectedProject = useMemo(
+    () => projects.find((project) => project.id === selectedProjectId) || null,
+    [projects, selectedProjectId]
+  );
+
+  const selectedModule = useMemo(
+    () => modules.find((module) => module.id === selectedModuleId) || null,
+    [modules, selectedModuleId]
+  );
+
+  const selectedWorkflow = useMemo(() => {
+    if (!selectedModule || !selectedProject) return null;
+    const workflowId = selectedModule.workflowId || selectedProject.workflowId;
+    return workflows.find((workflow) => workflow.id === workflowId) || null;
+  }, [selectedModule, selectedProject, workflows]);
+
+  const handleCreateStage = (event) => {
+    event.preventDefault();
+    if (!stageName.trim()) return;
+    const newStage = { id: `stage-${createId()}`, name: stageName.trim() };
+    setStages((prev) => [...prev, newStage]);
+    setStageName('');
+  };
+
+  const handleCreateTaskType = (event) => {
+    event.preventDefault();
+    if (!taskTypeName.trim()) return;
+    const newTaskType = { id: `type-${createId()}`, name: taskTypeName.trim() };
+    setTaskTypes((prev) => [...prev, newTaskType]);
+    setTaskTypeName('');
+  };
+
+  const handleCreateWorkflow = (event) => {
+    event.preventDefault();
+    if (!workflowForm.name.trim() || workflowForm.stageIds.length === 0) return;
+    const newWorkflow = {
+      id: `workflow-${createId()}`,
+      name: workflowForm.name.trim(),
+      stageIds: workflowForm.stageIds,
+      taskTypeIds: workflowForm.taskTypeIds
+    };
+    setWorkflows((prev) => [...prev, newWorkflow]);
+    setWorkflowForm({ name: '', stageIds: [], taskTypeIds: [] });
+  };
+
+  const handleCreateProject = (event) => {
+    event.preventDefault();
+    if (!projectForm.name.trim() || !projectForm.workflowId) return;
+    const newProject = {
+      id: `project-${createId()}`,
+      name: projectForm.name.trim(),
+      workflowId: projectForm.workflowId
+    };
+    setProjects((prev) => [...prev, newProject]);
+    setProjectForm({ name: '', workflowId: projectForm.workflowId });
+    setSelectedProjectId(newProject.id);
+  };
+
+  const handleCreateModule = (event) => {
+    event.preventDefault();
+    if (!moduleForm.name.trim() || !moduleForm.projectId) return;
+    const newModule = {
+      id: `module-${createId()}`,
+      projectId: moduleForm.projectId,
+      name: moduleForm.name.trim(),
+      workflowId: moduleForm.workflowId || null
+    };
+    setModules((prev) => [...prev, newModule]);
+    setModuleForm({ ...moduleForm, name: '' });
+    setSelectedProjectId(newModule.projectId);
+    setSelectedModuleId(newModule.id);
+  };
+
+  const handleAddTask = (taskPayload) => {
+    const newTask = {
+      id: `task-${createId()}`,
+      ...taskPayload
+    };
+    setTasks((prev) => [...prev, newTask]);
+  };
+
+  return (
+    <div className="app-container">
+      <h1>FlowTask 项目管理中心</h1>
+      <div className="grid-layout">
+        <div className="card">
+          <h2>基础配置</h2>
+          <div>
+            <div className="section-title">创建阶段</div>
+            <form onSubmit={handleCreateStage}>
+              <input
+                value={stageName}
+                onChange={(event) => setStageName(event.target.value)}
+                placeholder="阶段名称"
+              />
+              <button type="submit">添加阶段</button>
+            </form>
+            <ul className="entity-list">
+              {stages.map((stage) => (
+                <li key={stage.id} className="entity-item">
+                  {stage.name}
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div>
+            <div className="section-title">创建任务类型</div>
+            <form onSubmit={handleCreateTaskType}>
+              <input
+                value={taskTypeName}
+                onChange={(event) => setTaskTypeName(event.target.value)}
+                placeholder="任务类型名称"
+              />
+              <button type="submit">添加任务类型</button>
+            </form>
+            <ul className="entity-list">
+              {taskTypes.map((taskType) => (
+                <li key={taskType.id} className="entity-item">
+                  {taskType.name}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        <div className="card">
+          <h2>工作流管理</h2>
+          <form onSubmit={handleCreateWorkflow}>
+            <input
+              value={workflowForm.name}
+              onChange={(event) =>
+                setWorkflowForm((prev) => ({ ...prev, name: event.target.value }))
+              }
+              placeholder="工作流名称"
+            />
+            <label className="section-title">选择阶段</label>
+            <select
+              multiple
+              value={workflowForm.stageIds}
+              onChange={(event) =>
+                setWorkflowForm((prev) => ({
+                  ...prev,
+                  stageIds: Array.from(event.target.selectedOptions, (option) => option.value)
+                }))
+              }
+            >
+              {stages.map((stage) => (
+                <option key={stage.id} value={stage.id}>
+                  {stage.name}
+                </option>
+              ))}
+            </select>
+            <label className="section-title">选择任务类型</label>
+            <select
+              multiple
+              value={workflowForm.taskTypeIds}
+              onChange={(event) =>
+                setWorkflowForm((prev) => ({
+                  ...prev,
+                  taskTypeIds: Array.from(event.target.selectedOptions, (option) => option.value)
+                }))
+              }
+            >
+              {taskTypes.map((taskType) => (
+                <option key={taskType.id} value={taskType.id}>
+                  {taskType.name}
+                </option>
+              ))}
+            </select>
+            <button type="submit">创建工作流</button>
+          </form>
+
+          <div className="section-title">现有工作流</div>
+          <ul className="entity-list">
+            {workflows.map((workflow) => (
+              <li key={workflow.id} className="entity-item">
+                <div>{workflow.name}</div>
+                <div className="task-meta">
+                  阶段：{workflow.stageIds
+                    .map((stageId) => stages.find((stage) => stage.id === stageId)?.name)
+                    .filter(Boolean)
+                    .join(' / ')}
+                </div>
+                <div className="task-meta">
+                  任务类型：{workflow.taskTypeIds
+                    .map((typeId) => taskTypes.find((type) => type.id === typeId)?.name)
+                    .filter(Boolean)
+                    .join(' / ')}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="card">
+          <h2>项目与模块</h2>
+          <div className="section-title">创建项目</div>
+          <form onSubmit={handleCreateProject}>
+            <input
+              value={projectForm.name}
+              onChange={(event) => setProjectForm((prev) => ({ ...prev, name: event.target.value }))}
+              placeholder="项目名称"
+            />
+            <select
+              value={projectForm.workflowId}
+              onChange={(event) =>
+                setProjectForm((prev) => ({ ...prev, workflowId: event.target.value }))
+              }
+            >
+              {workflows.map((workflow) => (
+                <option key={workflow.id} value={workflow.id}>
+                  {workflow.name}
+                </option>
+              ))}
+            </select>
+            <button type="submit">创建项目</button>
+          </form>
+
+          <div className="section-title">创建模块</div>
+          <form onSubmit={handleCreateModule}>
+            <select
+              value={moduleForm.projectId}
+              onChange={(event) => setModuleForm((prev) => ({ ...prev, projectId: event.target.value }))}
+            >
+              {projects.map((project) => (
+                <option key={project.id} value={project.id}>
+                  {project.name}
+                </option>
+              ))}
+            </select>
+            <input
+              value={moduleForm.name}
+              onChange={(event) => setModuleForm((prev) => ({ ...prev, name: event.target.value }))}
+              placeholder="模块名称"
+            />
+            <select
+              value={moduleForm.workflowId || ''}
+              onChange={(event) =>
+                setModuleForm((prev) => ({
+                  ...prev,
+                  workflowId: event.target.value === '' ? null : event.target.value
+                }))
+              }
+            >
+              <option value="">使用项目默认工作流</option>
+              {workflows.map((workflow) => (
+                <option key={workflow.id} value={workflow.id}>
+                  {workflow.name}
+                </option>
+              ))}
+            </select>
+            <button type="submit">创建模块</button>
+          </form>
+
+          <div className="section-title">当前项目</div>
+          <ul className="entity-list">
+            {projects.map((project) => (
+              <li key={project.id} className="entity-item">
+                <div>{project.name}</div>
+                <div className="task-meta">
+                  工作流：{workflows.find((workflow) => workflow.id === project.workflowId)?.name || '未设置'}
+                </div>
+                <div className="task-meta">
+                  模块：
+                  {modules
+                    .filter((module) => module.projectId === project.id)
+                    .map((module) => module.name)
+                    .join(' / ') || '暂无'}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      <div className="card" style={{ marginTop: 24 }}>
+        <h2>模块工作台</h2>
+        <div className="module-selector">
+          <select
+            value={selectedProjectId}
+            onChange={(event) => {
+              setSelectedProjectId(event.target.value);
+              const targetProject = projects.find((project) => project.id === event.target.value);
+              const firstModule = modules.find((module) => module.projectId === targetProject?.id);
+              setSelectedModuleId(firstModule?.id || '');
+            }}
+          >
+            {projects.map((project) => (
+              <option key={project.id} value={project.id}>
+                {project.name}
+              </option>
+            ))}
+          </select>
+          <select
+            value={selectedModuleId || ''}
+            onChange={(event) => setSelectedModuleId(event.target.value)}
+          >
+            <option value="" disabled>
+              请选择模块
+            </option>
+            {modules
+              .filter((module) => module.projectId === selectedProjectId)
+              .map((module) => (
+                <option key={module.id} value={module.id}>
+                  {module.name}
+                </option>
+              ))}
+          </select>
+        </div>
+
+        {selectedModule && selectedProject && selectedWorkflow ? (
+          <ModuleView
+            module={selectedModule}
+            project={selectedProject}
+            workflow={selectedWorkflow}
+            stages={stages}
+            taskTypes={taskTypes}
+            tasks={tasks.filter((task) => task.moduleId === selectedModule.id)}
+            onAddTask={handleAddTask}
+            priorities={PRIORITIES}
+            statuses={STATUSES}
+          />
+        ) : (
+          <div className="empty-state">请选择模块查看任务看板。</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ModuleView.jsx
+++ b/src/components/ModuleView.jsx
@@ -1,0 +1,398 @@
+import { useEffect, useMemo, useState } from 'react';
+
+const createDraft = ({ defaultTaskTypeId, defaultPriority, defaultStatus }) => ({
+  name: '',
+  description: '',
+  taskTypeId: defaultTaskTypeId || '',
+  priority: defaultPriority,
+  status: defaultStatus,
+  startDate: '',
+  endDate: ''
+});
+
+const TaskTree = ({
+  task,
+  tasks,
+  taskTypesMap,
+  priorities,
+  statuses,
+  workflowTaskTypes,
+  subtaskDrafts,
+  onToggleSubtask,
+  onUpdateSubtaskDraft,
+  onSubmitSubtask
+}) => {
+  const subtasks = tasks.filter((item) => item.parentTaskId === task.id);
+  const draftState = subtaskDrafts[task.id];
+  const draft = draftState?.form;
+
+  return (
+    <div className="task-card">
+      <div className="task-meta">
+        <span className="badge">{taskTypesMap.get(task.taskTypeId)?.name || '未分类'}</span>
+        <span>优先级：{task.priority}</span>
+        <span>状态：{task.status}</span>
+        {task.startDate && <span>开始：{task.startDate}</span>}
+        {task.endDate && <span>结束：{task.endDate}</span>}
+      </div>
+      <div style={{ fontWeight: 600, marginBottom: 6 }}>{task.name}</div>
+      {task.description && <div style={{ fontSize: 13, color: '#475569', marginBottom: 8 }}>{task.description}</div>}
+      <div className="task-actions">
+        <button type="button" onClick={() => onToggleSubtask(task.id)}>
+          {draftState?.open ? '关闭子任务表单' : '添加子任务'}
+        </button>
+      </div>
+
+      {draftState?.open && (
+        <form
+          className="inline-form"
+          onSubmit={(event) => {
+            event.preventDefault();
+            onSubmitSubtask(task.id);
+          }}
+        >
+          <input
+            value={draft?.name || ''}
+            onChange={(event) => onUpdateSubtaskDraft(task.id, 'name', event.target.value)}
+            placeholder="子任务名称"
+          />
+          <select
+            value={draft?.taskTypeId || ''}
+            onChange={(event) => onUpdateSubtaskDraft(task.id, 'taskTypeId', event.target.value)}
+          >
+            <option value="" disabled>
+              选择任务类型
+            </option>
+            {workflowTaskTypes.map((type) => (
+              <option key={type.id} value={type.id}>
+                {type.name}
+              </option>
+            ))}
+          </select>
+          <select
+            value={draft?.priority || ''}
+            onChange={(event) => onUpdateSubtaskDraft(task.id, 'priority', event.target.value)}
+          >
+            {priorities.map((priority) => (
+              <option key={priority} value={priority}>
+                {priority}
+              </option>
+            ))}
+          </select>
+          <select
+            value={draft?.status || ''}
+            onChange={(event) => onUpdateSubtaskDraft(task.id, 'status', event.target.value)}
+          >
+            {statuses.map((status) => (
+              <option key={status} value={status}>
+                {status}
+              </option>
+            ))}
+          </select>
+          <input
+            type="date"
+            value={draft?.startDate || ''}
+            onChange={(event) => onUpdateSubtaskDraft(task.id, 'startDate', event.target.value)}
+          />
+          <input
+            type="date"
+            value={draft?.endDate || ''}
+            onChange={(event) => onUpdateSubtaskDraft(task.id, 'endDate', event.target.value)}
+          />
+          <textarea
+            rows={2}
+            value={draft?.description || ''}
+            onChange={(event) => onUpdateSubtaskDraft(task.id, 'description', event.target.value)}
+            placeholder="子任务描述"
+          />
+          <button type="submit">保存子任务</button>
+        </form>
+      )}
+
+      {subtasks.length > 0 && (
+        <div className="subtask-container">
+          {subtasks.map((subtask) => (
+            <TaskTree
+              key={subtask.id}
+              task={subtask}
+              tasks={tasks}
+              taskTypesMap={taskTypesMap}
+              priorities={priorities}
+              statuses={statuses}
+              workflowTaskTypes={workflowTaskTypes}
+              subtaskDrafts={subtaskDrafts}
+              onToggleSubtask={onToggleSubtask}
+              onUpdateSubtaskDraft={onUpdateSubtaskDraft}
+              onSubmitSubtask={onSubmitSubtask}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const ModuleView = ({
+  module,
+  project,
+  workflow,
+  stages,
+  taskTypes,
+  tasks,
+  onAddTask,
+  priorities,
+  statuses
+}) => {
+  const stageMap = useMemo(() => new Map(stages.map((stage) => [stage.id, stage])), [stages]);
+  const taskTypesMap = useMemo(
+    () => new Map(taskTypes.map((taskType) => [taskType.id, taskType])),
+    [taskTypes]
+  );
+
+  const workflowStages = workflow.stageIds
+    .map((stageId) => stageMap.get(stageId))
+    .filter(Boolean);
+  const workflowTaskTypes = workflow.taskTypeIds
+    .map((typeId) => taskTypesMap.get(typeId))
+    .filter(Boolean);
+
+  const defaultTaskTypeId = workflowTaskTypes[0]?.id || '';
+  const defaultPriority = priorities[Math.floor(priorities.length / 2)] || '';
+  const defaultStatus = statuses[0] || '';
+
+  const [stageDrafts, setStageDrafts] = useState({});
+  const [subtaskDrafts, setSubtaskDrafts] = useState({});
+
+  useEffect(() => {
+    setStageDrafts((prev) => {
+      const next = { ...prev };
+      workflow.stageIds.forEach((stageId) => {
+        if (!next[stageId]) {
+          next[stageId] = createDraft({
+            defaultTaskTypeId,
+            defaultPriority,
+            defaultStatus
+          });
+        }
+      });
+      Object.keys(next).forEach((stageId) => {
+        if (!workflow.stageIds.includes(stageId)) {
+          delete next[stageId];
+        }
+      });
+      return next;
+    });
+  }, [workflow.stageIds, defaultTaskTypeId, defaultPriority, defaultStatus]);
+
+  useEffect(() => {
+    setSubtaskDrafts({});
+  }, [module.id, workflow.id]);
+
+  const updateStageDraft = (stageId, field, value) => {
+    setStageDrafts((prev) => ({
+      ...prev,
+      [stageId]: {
+        ...prev[stageId],
+        [field]: value
+      }
+    }));
+  };
+
+  const handleSubmitStageTask = (stageId, event) => {
+    event.preventDefault();
+    const draft = stageDrafts[stageId];
+    if (!draft || !draft.name.trim()) return;
+    const taskTypeId = draft.taskTypeId || defaultTaskTypeId;
+    if (!taskTypeId) return;
+    onAddTask({
+      moduleId: module.id,
+      stageId,
+      taskTypeId,
+      name: draft.name.trim(),
+      description: draft.description.trim(),
+      priority: draft.priority,
+      status: draft.status,
+      startDate: draft.startDate,
+      endDate: draft.endDate,
+      parentTaskId: null
+    });
+    setStageDrafts((prev) => ({
+      ...prev,
+      [stageId]: createDraft({ defaultTaskTypeId, defaultPriority, defaultStatus })
+    }));
+  };
+
+  const toggleSubtask = (taskId) => {
+    setSubtaskDrafts((prev) => {
+      const next = { ...prev };
+      const current = next[taskId];
+      if (!current) {
+        next[taskId] = {
+          open: true,
+          form: createDraft({ defaultTaskTypeId, defaultPriority, defaultStatus })
+        };
+      } else {
+        next[taskId] = { ...current, open: !current.open };
+      }
+      return next;
+    });
+  };
+
+  const updateSubtaskDraft = (taskId, field, value) => {
+    setSubtaskDrafts((prev) => {
+      const current = prev[taskId] || {
+        open: true,
+        form: createDraft({ defaultTaskTypeId, defaultPriority, defaultStatus })
+      };
+      return {
+        ...prev,
+        [taskId]: {
+          open: true,
+          form: {
+            ...current.form,
+            [field]: value
+          }
+        }
+      };
+    });
+  };
+
+  const submitSubtask = (taskId) => {
+    const draftState = subtaskDrafts[taskId];
+    const draft = draftState?.form;
+    if (!draft || !draft.name.trim()) return;
+    const parentTask = tasks.find((task) => task.id === taskId);
+    if (!parentTask) return;
+    const taskTypeId = draft.taskTypeId || defaultTaskTypeId;
+    if (!taskTypeId) return;
+    onAddTask({
+      moduleId: module.id,
+      stageId: parentTask.stageId,
+      taskTypeId,
+      name: draft.name.trim(),
+      description: draft.description.trim(),
+      priority: draft.priority,
+      status: draft.status,
+      startDate: draft.startDate,
+      endDate: draft.endDate,
+      parentTaskId: taskId
+    });
+    setSubtaskDrafts((prev) => ({
+      ...prev,
+      [taskId]: {
+        open: true,
+        form: createDraft({ defaultTaskTypeId, defaultPriority, defaultStatus })
+      }
+    }));
+  };
+
+  return (
+    <div>
+      <div className="task-meta" style={{ marginBottom: 8 }}>
+        <span>所属项目：{project.name}</span>
+        <span>模块：{module.name}</span>
+        <span>工作流：{workflow.name}</span>
+      </div>
+      <div className="workflow-stage-grid">
+        {workflowStages.map((stage) => {
+          const stageTasks = tasks.filter(
+            (task) => task.stageId === stage.id && task.parentTaskId === null
+          );
+
+          const draft = stageDrafts[stage.id] || createDraft({
+            defaultTaskTypeId,
+            defaultPriority,
+            defaultStatus
+          });
+
+          return (
+            <div key={stage.id} className="stage-column">
+              <h3>{stage.name}</h3>
+              <form className="inline-form" onSubmit={(event) => handleSubmitStageTask(stage.id, event)}>
+                <input
+                  value={draft.name}
+                  onChange={(event) => updateStageDraft(stage.id, 'name', event.target.value)}
+                  placeholder="任务名称"
+                />
+                <select
+                  value={draft.taskTypeId}
+                  onChange={(event) => updateStageDraft(stage.id, 'taskTypeId', event.target.value)}
+                >
+                  <option value="" disabled>
+                    选择任务类型
+                  </option>
+                  {workflowTaskTypes.map((type) => (
+                    <option key={type.id} value={type.id}>
+                      {type.name}
+                    </option>
+                  ))}
+                </select>
+                <select
+                  value={draft.priority}
+                  onChange={(event) => updateStageDraft(stage.id, 'priority', event.target.value)}
+                >
+                  {priorities.map((priority) => (
+                    <option key={priority} value={priority}>
+                      {priority}
+                    </option>
+                  ))}
+                </select>
+                <select
+                  value={draft.status}
+                  onChange={(event) => updateStageDraft(stage.id, 'status', event.target.value)}
+                >
+                  {statuses.map((status) => (
+                    <option key={status} value={status}>
+                      {status}
+                    </option>
+                  ))}
+                </select>
+                <input
+                  type="date"
+                  value={draft.startDate}
+                  onChange={(event) => updateStageDraft(stage.id, 'startDate', event.target.value)}
+                />
+                <input
+                  type="date"
+                  value={draft.endDate}
+                  onChange={(event) => updateStageDraft(stage.id, 'endDate', event.target.value)}
+                />
+                <textarea
+                  rows={2}
+                  value={draft.description}
+                  onChange={(event) => updateStageDraft(stage.id, 'description', event.target.value)}
+                  placeholder="任务描述"
+                />
+                <button type="submit">保存任务</button>
+              </form>
+
+              <div style={{ marginTop: 12 }}>
+                {stageTasks.length > 0 ? (
+                  stageTasks.map((task) => (
+                    <TaskTree
+                      key={task.id}
+                      task={task}
+                      tasks={tasks}
+                      taskTypesMap={taskTypesMap}
+                      priorities={priorities}
+                      statuses={statuses}
+                      workflowTaskTypes={workflowTaskTypes}
+                      subtaskDrafts={subtaskDrafts}
+                      onToggleSubtask={toggleSubtask}
+                      onUpdateSubtaskDraft={updateSubtaskDraft}
+                      onSubmitSubtask={submitSubtask}
+                    />
+                  ))
+                ) : (
+                  <div className="empty-state">暂无任务</div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default ModuleView;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,190 @@
+:root {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  color-scheme: light;
+  background-color: #f5f7fb;
+  color: #1f2933;
+}
+
+body {
+  margin: 0;
+  background-color: #f5f7fb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.app-container {
+  padding: 24px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+h1 {
+  margin-top: 0;
+  margin-bottom: 24px;
+}
+
+.grid-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 16px;
+}
+
+.card {
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.card h2 {
+  margin: 0;
+  font-size: 18px;
+  color: #1f2937;
+}
+
+.card form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.card input,
+.card select,
+.card textarea {
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid #d1d5db;
+  font-size: 14px;
+}
+
+.card button {
+  border: none;
+  background-color: #2563eb;
+  color: white;
+  padding: 8px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.card button:hover {
+  background-color: #1e40af;
+}
+
+.section-title {
+  font-size: 16px;
+  font-weight: 600;
+  margin-top: 16px;
+  margin-bottom: 8px;
+}
+
+.entity-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.entity-item {
+  background-color: #f1f5f9;
+  border-radius: 8px;
+  padding: 8px;
+  font-size: 14px;
+}
+
+.workflow-stage-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  margin-top: 16px;
+}
+
+.stage-column {
+  background-color: #f8fafc;
+  border-radius: 12px;
+  padding: 16px;
+  border: 1px solid #e2e8f0;
+}
+
+.stage-column h3 {
+  margin-top: 0;
+  margin-bottom: 12px;
+  font-size: 16px;
+}
+
+.task-card {
+  background: white;
+  border-radius: 10px;
+  border: 1px solid #e2e8f0;
+  padding: 12px;
+  margin-bottom: 10px;
+  box-shadow: 0 4px 12px rgba(148, 163, 184, 0.2);
+}
+
+.task-meta {
+  font-size: 12px;
+  color: #64748b;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.subtask-container {
+  margin-left: 16px;
+  border-left: 2px dashed #cbd5f5;
+  padding-left: 12px;
+  margin-top: 10px;
+}
+
+.module-selector {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.module-selector select {
+  flex: 1;
+}
+
+.empty-state {
+  padding: 16px;
+  background-color: #e2e8f0;
+  border-radius: 8px;
+  color: #475569;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  background-color: #e0e7ff;
+  color: #3730a3;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 12px;
+}
+
+.task-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.inline-form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.inline-form button {
+  grid-column: span 2;
+  justify-self: start;
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: '0.0.0.0',
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite React application for the FlowTask project management mockup
- implement project, workflow, module, and task creation flows with nested task support
- add a module workspace view that visualizes workflow stages and allows creating prioritized tasks and subtasks

## Testing
- npm install *(fails: registry returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68e61532a7dc83308cc2b6089bc32303