### PR TITLE
Revamp stage configuration and module workspace

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -99,35 +99,6 @@ h1 {
   font-size: 14px;
 }
 
-.workflow-stage-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 16px;
-  margin-top: 16px;
-}
-
-.stage-column {
-  background-color: #f8fafc;
-  border-radius: 12px;
-  padding: 16px;
-  border: 1px solid #e2e8f0;
-}
-
-.stage-column h3 {
-  margin-top: 0;
-  margin-bottom: 12px;
-  font-size: 16px;
-}
-
-.task-card {
-  background: white;
-  border-radius: 10px;
-  border: 1px solid #e2e8f0;
-  padding: 12px;
-  margin-bottom: 10px;
-  box-shadow: 0 4px 12px rgba(148, 163, 184, 0.2);
-}
-
 .task-meta {
   font-size: 12px;
   color: #64748b;
@@ -135,13 +106,6 @@ h1 {
   flex-wrap: wrap;
   gap: 8px;
   margin-bottom: 8px;
-}
-
-.subtask-container {
-  margin-left: 16px;
-  border-left: 2px dashed #cbd5f5;
-  padding-left: 12px;
-  margin-top: 10px;
 }
 
 .module-selector {
@@ -171,20 +135,249 @@ h1 {
   font-size: 12px;
 }
 
+.entity-item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+  font-weight: 600;
+}
+
+.entity-item-count {
+  font-size: 12px;
+  color: #64748b;
+}
+
+.stage-task-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 12px;
+}
+
+.stage-task-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-size: 13px;
+}
+
+.stage-task-type {
+  font-size: 12px;
+  color: #3730a3;
+  background-color: #e0e7ff;
+  border-radius: 999px;
+  padding: 2px 8px;
+}
+
+.stage-task-empty {
+  padding: 10px;
+  border-radius: 8px;
+  background-color: #e2e8f0;
+  color: #64748b;
+  font-size: 13px;
+}
+
+.stage-task-form {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.stage-task-form button {
+  margin-top: 0;
+  height: 36px;
+}
+
+.stage-task-form input,
+.stage-task-form select {
+  height: 36px;
+}
+
+.module-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 12px;
+}
+
+.module-toolbar button {
+  align-self: flex-end;
+}
+
+.task-table-container {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  overflow: hidden;
+  background-color: #ffffff;
+}
+
+.task-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.task-table thead {
+  background-color: #f8fafc;
+}
+
+.task-table th,
+.task-table td {
+  padding: 12px 14px;
+  font-size: 14px;
+  border-bottom: 1px solid #e2e8f0;
+  text-align: left;
+  color: #1f2937;
+}
+
+.task-table tbody tr:hover {
+  background-color: #f8fafc;
+}
+
+.stage-header td {
+  background-color: #e0f2fe;
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.task-name-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.task-name-title {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.task-name-description {
+  font-size: 12px;
+  color: #64748b;
+}
+
+.task-actions button {
+  border: none;
+  background-color: #2563eb;
+  color: white;
+  padding: 6px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.task-actions button:hover {
+  background-color: #1e40af;
+}
+
+.secondary-action {
+  background-color: #e2e8f0;
+  color: #1f2937;
+}
+
+.secondary-action:hover {
+  background-color: #cbd5f5;
+}
+
+.card .secondary-action,
+.dialog-footer .secondary-action {
+  background-color: #e2e8f0;
+  color: #1f2937;
+}
+
+.card .secondary-action:hover,
+.dialog-footer .secondary-action:hover {
+  background-color: #cbd5f5;
+}
+
+.empty-row td {
+  text-align: center;
+  color: #64748b;
+  font-style: italic;
+}
+
+.dialog-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  z-index: 1000;
+}
+
+.dialog {
+  background-color: #ffffff;
+  border-radius: 16px;
+  width: min(640px, 100%);
+  padding: 24px;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.15);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.dialog h3 {
+  margin: 0;
+  font-size: 18px;
+  color: #1f2937;
+}
+
+.dialog-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.dialog-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.dialog-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 14px;
+  color: #475569;
+}
+
+.dialog-field input,
+.dialog-field select,
+.dialog-field textarea {
+  width: 100%;
+  border-radius: 8px;
+  border: 1px solid #d1d5db;
+  padding: 8px 10px;
+  font-size: 14px;
+}
+
+.dialog-field textarea {
+  resize: vertical;
+  min-height: 96px;
+}
+
+.dialog-field--wide {
+  grid-column: 1 / -1;
+}
+
+.dialog-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.dialog-footer button {
+  min-width: 92px;
+}
+
 .task-actions {
   display: flex;
   gap: 8px;
-  flex-wrap: wrap;
-}
-
-.inline-form {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 8px;
-  margin-top: 8px;
-}
-
-.inline-form button {
-  grid-column: span 2;
-  justify-self: start;
 }


### PR DESCRIPTION
## Summary
- allow configuring per-stage template tasks with optional task type information from the基础配置 panel
- simplify workflow management by removing task-type bindings while keeping multi-stage selection support
- rebuild the module workspace as a tree-structured task table with modal-based create and edit flows, alongside refreshed styles

## Testing
- npm install *(fails: registry returns 403 Forbidden for @vitejs/plugin-react)*
- npm run build *(fails: vite command not found because dependencies are unavailable without install)*

------
https://chatgpt.com/codex/tasks/task_e_68e629917af48330968b7a6e3a53b032