### PR TITLE
refactor: use tables and dialogs for configuration management

### DIFF
--- a/src/components/Modal.css
+++ b/src/components/Modal.css
@@ -1,0 +1,53 @@
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 16px;
+}
+
+.modal-content {
+  background: #fff;
+  border-radius: 8px;
+  width: min(640px, 100%);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.12);
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 20px;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.modal-body {
+  padding: 20px;
+  overflow-y: auto;
+}
+
+.modal-footer {
+  padding: 16px 20px;
+  border-top: 1px solid #f0f0f0;
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.modal-close {
+  background: transparent;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+  color: #666;
+}
+
+.modal-close:hover {
+  color: #000;
+}

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,0 +1,20 @@
+import './Modal.css';
+
+export default function Modal({ isOpen, title, onClose, children, footer }) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="modal-backdrop" role="dialog" aria-modal="true">
+      <div className="modal-content">
+        <div className="modal-header">
+          <h3>{title}</h3>
+          <button type="button" className="modal-close" onClick={onClose} aria-label="关闭">
+            ×
+          </button>
+        </div>
+        <div className="modal-body">{children}</div>
+        {footer ? <div className="modal-footer">{footer}</div> : null}
+      </div>
+    </div>
+  );
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -47,22 +47,9 @@ h1 {
   color: #1f2937;
 }
 
-.card form {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.card input,
-.card select,
-.card textarea {
-  padding: 8px 10px;
-  border-radius: 8px;
-  border: 1px solid #d1d5db;
-  font-size: 14px;
-}
-
-.card button {
+.card button,
+.modal-footer button,
+.stage-task-modal-form button {
   border: none;
   background-color: #2563eb;
   color: white;
@@ -72,8 +59,22 @@ h1 {
   font-size: 14px;
 }
 
-.card button:hover {
+.card button:hover,
+.modal-footer button:hover,
+.stage-task-modal-form button:hover {
   background-color: #1e40af;
+}
+
+.card input,
+.card select,
+.card textarea,
+.modal-content input,
+.modal-content select,
+.modal-content textarea {
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid #d1d5db;
+  font-size: 14px;
 }
 
 .section-title {
@@ -81,6 +82,128 @@ h1 {
   font-weight: 600;
   margin-top: 16px;
   margin-bottom: 8px;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+  border-radius: 8px;
+  overflow: hidden;
+  font-size: 14px;
+}
+
+.data-table thead {
+  background-color: #eef2ff;
+}
+
+.data-table th,
+.data-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid #e2e8f0;
+  text-align: left;
+}
+
+.data-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.table-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.table-actions button {
+  padding: 6px 12px;
+  font-size: 13px;
+}
+
+.secondary {
+  background-color: #e2e8f0 !important;
+  color: #475569 !important;
+}
+
+.secondary:hover {
+  background-color: #cbd5f5 !important;
+  color: #1e293b !important;
+}
+
+.danger {
+  background-color: #dc2626 !important;
+}
+
+.danger:hover {
+  background-color: #b91c1c !important;
+}
+
+.form-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 16px;
+}
+
+.form-item label {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.stage-task-modal-form {
+  display: grid;
+  grid-template-columns: 1fr 180px auto auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.stage-task-modal-form .secondary {
+  justify-self: start;
+}
+
+.checkbox-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+}
+
+.checkbox-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+}
+
+.empty-cell {
+  text-align: center;
+  color: #94a3b8;
+  padding: 16px;
+}
+
+.empty-inline {
+  color: #94a3b8;
+  font-size: 13px;
+}
+
+.card-header button,
+.section-header button {
+  flex-shrink: 0;
 }
 
 .entity-list {


### PR DESCRIPTION
## Summary
- replace the base configuration, workflow, and project/module sections with table layouts that open modal dialogs for add/edit actions
- introduce a reusable modal component and updated styling to support the new table-driven UI
- allow stage tasks to be managed within the stage dialog, including inline add/update/delete

## Testing
- npm install *(fails: 403 Forbidden when fetching @vitejs/plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_68e6439b65c48330b9f98f127155f997