### PR TITLE
feat: align module task creation with workflow stages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -723,6 +723,7 @@ export default function App() {
             stages={stages}
             taskTypes={taskTypes}
             tasks={tasks.filter((task) => task.moduleId === selectedModule.id)}
+            stageTemplates={stageTasks}
             onAddTask={handleAddTask}
             onUpdateTask={handleUpdateTask}
             priorities={PRIORITIES}

--- a/src/styles.css
+++ b/src/styles.css
@@ -361,6 +361,16 @@ h1 {
   background-color: #f8fafc;
 }
 
+.template-row td {
+  background-color: #f1f5f9;
+  color: #475569;
+}
+
+.task-template-hint {
+  font-size: 12px;
+  color: #94a3b8;
+}
+
 .stage-header td {
   background-color: #e0f2fe;
   color: #0f172a;
@@ -404,6 +414,19 @@ h1 {
 
 .secondary-action:hover {
   background-color: #cbd5f5;
+}
+
+.template-tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 72px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background-color: #e0e7ff;
+  color: #3730a3;
+  font-size: 12px;
+  font-weight: 600;
 }
 
 .card .secondary-action,


### PR DESCRIPTION
## Summary
- restrict module task stage options to the stages defined by the module workflow
- expose stage-defined template tasks in the module workspace table with visual labeling
- enable choosing a hierarchical parent task when creating tasks and add supporting styles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e649899a208330b86a813a3ef52ddb