### PR TITLE
Fix Spring Boot run configuration for Kotlin backend

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -16,6 +16,8 @@
   <properties>
     <java.version>17</java.version>
     <kotlin.version>1.9.24</kotlin.version>
+    <spring-boot.run.main-class>com.example.flowtask.FlowTaskApplicationKt</spring-boot.run.main-class>
+    <start-class>com.example.flowtask.FlowTaskApplicationKt</start-class>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## Summary
- declare the generated Kotlin entry point as the Spring Boot main class so spring-boot:run can locate it

## Testing
- mvn spring-boot:run -Dspring-boot.run.arguments=--spring.main.web-application-type=none *(fails: unable to download dependencies in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e666a9d1308330930b8f2f018fff72