### PR TITLE
Disable authentication prompt on site load

### DIFF
--- a/backend/src/main/kotlin/com/example/flowtask/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/com/example/flowtask/config/SecurityConfig.kt
@@ -1,0 +1,22 @@
+package com.example.flowtask.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+class SecurityConfig {
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .csrf { it.disable() }
+            .authorizeHttpRequests { requests ->
+                requests.anyRequest().permitAll()
+            }
+            .httpBasic { it.disable() }
+            .formLogin { it.disable() }
+
+        return http.build()
+    }
+}


### PR DESCRIPTION
## Summary
- add a Spring Security filter chain configuration that disables HTTP basic auth and permits all requests

## Testing
- `mvn -q test` *(fails: unable to download parent POM because Maven Central responded with 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e66c99f0008330aa60217dc9635828