### PR TITLE
Add stage task templates and module filters

### DIFF
--- a/backend/src/main/kotlin/com/example/flowtask/api/FlowDataModels.kt
+++ b/backend/src/main/kotlin/com/example/flowtask/api/FlowDataModels.kt
@@ -2,7 +2,15 @@ package com.example.flowtask.api
 
 data class Stage(
     val id: String,
-    val name: String
+    val name: String,
+    val tasks: List<StageTask> = emptyList()
+)
+
+data class StageTask(
+    val id: String,
+    val stageId: String,
+    val name: String,
+    val sortOrder: Int
 )
 
 data class TaskType(
@@ -53,6 +61,11 @@ data class FlowDataResponse(
 )
 
 data class StageRequest(
+    val name: String,
+    val tasks: List<StageTaskRequest> = emptyList()
+)
+
+data class StageTaskRequest(
     val name: String
 )
 

--- a/backend/src/main/resources/db/migration/V2__create_stage_tasks.sql
+++ b/backend/src/main/resources/db/migration/V2__create_stage_tasks.sql
@@ -1,0 +1,13 @@
+CREATE TABLE stage_tasks (
+    id VARCHAR(64) PRIMARY KEY,
+    stage_id VARCHAR(64) NOT NULL,
+    name VARCHAR(200) NOT NULL,
+    sort_order INT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_stage_tasks_stage FOREIGN KEY (stage_id) REFERENCES stages(id) ON DELETE CASCADE
+);
+
+INSERT INTO stage_tasks (id, stage_id, name, sort_order) VALUES
+  ('stage-plan-template-1', 'stage-plan', '需求澄清', 0),
+  ('stage-build-template-1', 'stage-build', '开发实现', 0),
+  ('stage-review-template-1', 'stage-review', '上线验收', 0);

--- a/src/styles.css
+++ b/src/styles.css
@@ -70,6 +70,29 @@ body {
   gap: 16px;
 }
 
+.selection-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: flex-end;
+  padding: 16px;
+  border-radius: 12px;
+  background-color: #ffffff;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+}
+
+.selection-toolbar label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+  color: #475569;
+}
+
+.selection-toolbar select {
+  min-width: 200px;
+}
+
 .empty-panel {
   padding: 24px;
   border-radius: 12px;
@@ -179,6 +202,64 @@ body {
 
 .data-table tbody tr:last-child td {
   border-bottom: none;
+}
+
+.muted-text {
+  color: #64748b;
+  font-size: 13px;
+}
+
+.stage-task-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.stage-task-list li {
+  background-color: #e0e7ff;
+  color: #3730a3;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.stage-task-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.stage-task-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.stage-task-row input {
+  flex: 1;
+}
+
+.stage-task-remove-button {
+  border: none;
+  background: none;
+  color: #dc2626;
+  cursor: pointer;
+  font-size: 13px;
+  padding: 4px 6px;
+  border-radius: 4px;
+}
+
+.stage-task-remove-button:hover {
+  text-decoration: underline;
+}
+
+.stage-task-add-button {
+  align-self: flex-start;
+  margin-top: 4px;
 }
 
 .table-actions {


### PR DESCRIPTION
## Summary
- allow creating and editing stage task templates that surface in the management table
- persist stage task definitions on the backend via a new `stage_tasks` table and include them in API payloads
- add project/module selectors above the task table with updated styling for the new UI elements

## Testing
- npm run build
- mvn -f backend/pom.xml test *(fails: Maven Central returned 403 when resolving the Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68e6700411948330b8e0b86b6d642a17