### PR TITLE
feat: surface stage template tasks in module view

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -209,6 +209,16 @@ body {
   font-size: 13px;
 }
 
+.template-task-row .task-name-title {
+  color: #334155;
+}
+
+.task-label {
+  margin-left: 4px;
+  color: #64748b;
+  font-size: 12px;
+}
+
 .stage-task-list {
   list-style: none;
   margin: 0;


### PR DESCRIPTION
## Summary
- display stage-level template tasks inside the module task table alongside module tasks
- expose the templates in the parent task selector while keeping them read-only
- style template task rows and labels so they are easy to distinguish

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e674538a308330bd51083b8692eb0c