### PR TITLE
Allow stage tasks to include subtasks

### DIFF
--- a/backend/src/main/kotlin/com/example/flowtask/api/FlowDataModels.kt
+++ b/backend/src/main/kotlin/com/example/flowtask/api/FlowDataModels.kt
@@ -10,6 +10,14 @@ data class StageTask(
     val id: String,
     val stageId: String,
     val name: String,
+    val sortOrder: Int,
+    val subtasks: List<StageSubtask> = emptyList()
+)
+
+data class StageSubtask(
+    val id: String,
+    val stageTaskId: String,
+    val name: String,
     val sortOrder: Int
 )
 
@@ -66,6 +74,11 @@ data class StageRequest(
 )
 
 data class StageTaskRequest(
+    val name: String,
+    val subtasks: List<StageSubtaskRequest> = emptyList()
+)
+
+data class StageSubtaskRequest(
     val name: String
 )
 

--- a/backend/src/main/resources/db/migration/V3__create_stage_task_subtasks.sql
+++ b/backend/src/main/resources/db/migration/V3__create_stage_task_subtasks.sql
@@ -1,0 +1,8 @@
+CREATE TABLE stage_task_subtasks (
+    id VARCHAR(64) PRIMARY KEY,
+    stage_task_id VARCHAR(64) NOT NULL,
+    name VARCHAR(200) NOT NULL,
+    sort_order INT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_stage_task_subtasks_stage_task FOREIGN KEY (stage_task_id) REFERENCES stage_tasks(id) ON DELETE CASCADE
+);

--- a/src/components/ModuleView.jsx
+++ b/src/components/ModuleView.jsx
@@ -29,19 +29,36 @@ const ModuleView = ({
     stages.forEach((stage) => {
       const templates = [...(stage.tasks || [])]
         .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0))
-        .map((task) => ({
-          id: task.id,
-          stageId: stage.id,
-          name: task.name,
-          taskTypeId: null,
-          priority: '',
-          status: '',
-          startDate: '',
-          endDate: '',
-          description: '',
-          children: [],
-          isTemplate: true
-        }));
+        .map((task) => {
+          const children = [...(task.subtasks || [])]
+            .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0))
+            .map((subtask) => ({
+              id: subtask.id,
+              stageId: stage.id,
+              name: subtask.name,
+              taskTypeId: null,
+              priority: '',
+              status: '',
+              startDate: '',
+              endDate: '',
+              description: '',
+              children: [],
+              isTemplate: true
+            }));
+          return {
+            id: task.id,
+            stageId: stage.id,
+            name: task.name,
+            taskTypeId: null,
+            priority: '',
+            status: '',
+            startDate: '',
+            endDate: '',
+            description: '',
+            children,
+            isTemplate: true
+          };
+        });
       map.set(stage.id, templates);
     });
     return map;

--- a/src/styles.css
+++ b/src/styles.css
@@ -224,23 +224,54 @@ body {
   margin: 0;
   padding: 0;
   display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
+  flex-direction: column;
+  gap: 8px;
 }
 
-.stage-task-list li {
+.stage-task-list > li {
+  background-color: #eef2ff;
+  color: #1e3a8a;
+  padding: 8px 12px;
+  border-radius: 8px;
+}
+
+.stage-task-title {
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.stage-subtask-list {
+  list-style: none;
+  margin: 6px 0 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.stage-subtask-list li {
   background-color: #e0e7ff;
   color: #3730a3;
-  padding: 4px 10px;
-  border-radius: 999px;
+  padding: 4px 8px;
+  border-radius: 6px;
   font-size: 12px;
-  font-weight: 600;
+  font-weight: 500;
 }
 
 .stage-task-editor {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 12px;
+}
+
+.stage-task-group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 12px;
+  background-color: #f8fafc;
 }
 
 .stage-task-row {
@@ -250,6 +281,22 @@ body {
 }
 
 .stage-task-row input {
+  flex: 1;
+}
+
+.stage-subtask-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.stage-subtask-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.stage-subtask-row input {
   flex: 1;
 }
 
@@ -267,7 +314,8 @@ body {
   text-decoration: underline;
 }
 
-.stage-task-add-button {
+.stage-task-add-button,
+.stage-subtask-add-button {
   align-self: flex-start;
   margin-top: 4px;
 }
@@ -415,13 +463,6 @@ body {
 .entity-item-count {
   font-size: 12px;
   color: #64748b;
-}
-
-.stage-task-list {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  margin-bottom: 12px;
 }
 
 .stage-task-item {


### PR DESCRIPTION
## Summary
- add a stage task subtask model plus database migration so workflows return nested stage task templates
- persist and expose subtask details when creating or updating stages and surface them through the API
- update the React UI to edit nested stage tasks, reuse them as templates, and refresh styling for the new hierarchy

## Testing
- npm run build
- mvn -f backend/pom.xml test *(fails: unable to download spring-boot-starter-parent due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e676b5405083308a82f88e25e6fa3a