### PR TITLE
Allow parent task selection for stage templates

### DIFF
--- a/backend/src/main/kotlin/com/example/flowtask/api/FlowDataController.kt
+++ b/backend/src/main/kotlin/com/example/flowtask/api/FlowDataController.kt
@@ -121,6 +121,9 @@ class FlowDataController(private val flowDataService: FlowDataService) {
     @PostMapping("/tasks")
     fun createTask(@RequestBody request: TaskCreateRequest): Task {
         validateTaskPayload(request.moduleId, request.stageId, request.name, request.priority, request.status)
+        if (request.parentTaskId != null && request.parentStageTaskId != null) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Task cannot have both parent task and parent stage task")
+        }
         return flowDataService.createTask(request)
     }
 

--- a/backend/src/main/kotlin/com/example/flowtask/api/FlowDataModels.kt
+++ b/backend/src/main/kotlin/com/example/flowtask/api/FlowDataModels.kt
@@ -56,7 +56,8 @@ data class Task(
     val status: String,
     val startDate: String?,
     val endDate: String?,
-    val parentTaskId: String?
+    val parentTaskId: String?,
+    val parentStageTaskId: String?
 )
 
 data class FlowDataResponse(
@@ -112,7 +113,8 @@ data class TaskCreateRequest(
     val status: String,
     val startDate: String?,
     val endDate: String?,
-    val parentTaskId: String?
+    val parentTaskId: String?,
+    val parentStageTaskId: String?
 )
 
 data class TaskUpdateRequest(

--- a/backend/src/main/resources/db/migration/V4__add_parent_stage_task_reference.sql
+++ b/backend/src/main/resources/db/migration/V4__add_parent_stage_task_reference.sql
@@ -1,0 +1,6 @@
+ALTER TABLE tasks
+    ADD COLUMN parent_stage_task_id VARCHAR(64);
+
+ALTER TABLE tasks
+    ADD CONSTRAINT fk_task_parent_stage_task
+    FOREIGN KEY (parent_stage_task_id) REFERENCES stage_tasks(id);


### PR DESCRIPTION
## Summary
- add a migration so tasks can reference a parent stage task
- extend task data models and service logic to validate and persist parent stage task links
- update the module view to allow choosing stage template tasks as parents and display their children

## Testing
- npm run build
- mvn test *(fails: unable to download parent POM from Maven Central in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e67dc703ac833095d117dd61286929