### PR TITLE
Add dashboard pie chart for project task status overview

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import ModuleView from './components/ModuleView.jsx';
+import Dashboard from './components/Dashboard.jsx';
 import Modal from './components/Modal.jsx';
 
 const PRIORITIES = ['低', '中', '高'];
@@ -82,6 +83,7 @@ export default function App() {
 
   const [selectedProjectId, setSelectedProjectId] = useState('');
   const [selectedModuleId, setSelectedModuleId] = useState('');
+  const [moduleDistinctionEnabled, setModuleDistinctionEnabled] = useState(false);
 
   const loadData = useCallback(
     async ({ projectId: overrideProjectId, moduleId: overrideModuleId } = {}) => {
@@ -171,6 +173,26 @@ export default function App() {
     }
     return modules.filter((module) => module.projectId === selectedProjectId);
   }, [modules, selectedProjectId]);
+
+  const tasksForSelectedProject = useMemo(() => {
+    if (tasks.length === 0) {
+      return [];
+    }
+    if (!selectedProjectId) {
+      return tasks;
+    }
+    const moduleIds = new Set(modulesForSelectedProject.map((module) => module.id));
+    if (moduleIds.size === 0) {
+      return [];
+    }
+    return tasks.filter((task) => moduleIds.has(task.moduleId));
+  }, [modulesForSelectedProject, selectedProjectId, tasks]);
+
+  useEffect(() => {
+    if (moduleDistinctionEnabled && modulesForSelectedProject.length <= 1) {
+      setModuleDistinctionEnabled(false);
+    }
+  }, [moduleDistinctionEnabled, modulesForSelectedProject.length]);
 
   const closeStageModal = () => {
     setStageModalState({ open: false, mode: 'create', stageId: null, name: '', tasks: [createEmptyStageTask()] });
@@ -800,6 +822,14 @@ export default function App() {
           </div>
 
           <div className="content">
+            <Dashboard
+              project={selectedProject}
+              tasks={tasksForSelectedProject}
+              modules={modulesForSelectedProject}
+              statuses={STATUSES}
+              moduleDistinctionEnabled={moduleDistinctionEnabled}
+              onModuleDistinctionChange={setModuleDistinctionEnabled}
+            />
             <div className="selection-toolbar">
               <label>
                 <span>项目</span>

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,0 +1,299 @@
+import { useMemo } from 'react';
+
+const STATUS_COLORS = {
+  未开始: '#94a3b8',
+  进行中: '#60a5fa',
+  已完成: '#34d399'
+};
+
+const MODULE_COLOR_PALETTE = [
+  '#6366f1',
+  '#ec4899',
+  '#14b8a6',
+  '#f97316',
+  '#8b5cf6',
+  '#22d3ee',
+  '#f59e0b',
+  '#10b981'
+];
+
+const STATUS_SHADE_STEPS = [-0.18, 0.02, 0.18, 0.3];
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+const adjustColor = (hex, amount) => {
+  if (!hex) return '#94a3b8';
+  let normalized = hex.replace('#', '');
+  if (normalized.length === 3) {
+    normalized = normalized
+      .split('')
+      .map((char) => char + char)
+      .join('');
+  }
+  const num = parseInt(normalized, 16);
+  if (Number.isNaN(num)) return '#94a3b8';
+  const r = (num >> 16) & 0xff;
+  const g = (num >> 8) & 0xff;
+  const b = num & 0xff;
+
+  const transform = (channel) => {
+    if (amount < 0) {
+      return Math.round(channel * (1 + amount));
+    }
+    return Math.round(channel + (255 - channel) * amount);
+  };
+
+  const nextR = clamp(transform(r), 0, 255);
+  const nextG = clamp(transform(g), 0, 255);
+  const nextB = clamp(transform(b), 0, 255);
+  const nextHex = (nextR << 16) | (nextG << 8) | nextB;
+  return `#${nextHex.toString(16).padStart(6, '0')}`;
+};
+
+const describeSlice = (cx, cy, radius, startAngle, endAngle) => {
+  const startX = cx + radius * Math.cos(startAngle);
+  const startY = cy + radius * Math.sin(startAngle);
+  const endX = cx + radius * Math.cos(endAngle);
+  const endY = cy + radius * Math.sin(endAngle);
+  const largeArcFlag = endAngle - startAngle > Math.PI ? 1 : 0;
+  return [
+    'M',
+    cx,
+    cy,
+    'L',
+    startX,
+    startY,
+    'A',
+    radius,
+    radius,
+    0,
+    largeArcFlag,
+    1,
+    endX,
+    endY,
+    'Z'
+  ].join(' ');
+};
+
+const PieChart = ({ data, size = 240 }) => {
+  const total = data.reduce((acc, item) => acc + item.value, 0);
+  if (total === 0) {
+    return (
+      <div className="dashboard-chart-empty">暂无可用的任务数据</div>
+    );
+  }
+
+  const radius = size / 2;
+  const center = size / 2;
+  let currentAngle = -Math.PI / 2;
+
+  return (
+    <svg
+      className="dashboard-chart-svg"
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      role="img"
+      aria-label="任务状态饼图"
+    >
+      {data.map((item) => {
+        if (item.value <= 0) {
+          return null;
+        }
+        const sliceAngle = (item.value / total) * Math.PI * 2;
+        const startAngle = currentAngle;
+        const endAngle = startAngle + sliceAngle;
+        currentAngle = endAngle;
+        return (
+          <path
+            key={item.key}
+            d={describeSlice(center, center, radius, startAngle, endAngle)}
+            fill={item.color}
+            stroke="#ffffff"
+            strokeWidth={1.5}
+          >
+            <title>{`${item.label}: ${item.value} (${item.percentage})`}</title>
+          </path>
+        );
+      })}
+    </svg>
+  );
+};
+
+const Dashboard = ({
+  project,
+  tasks,
+  modules,
+  statuses,
+  moduleDistinctionEnabled,
+  onModuleDistinctionChange
+}) => {
+  const moduleColorMap = useMemo(() => {
+    const map = new Map();
+    modules.forEach((module, index) => {
+      map.set(module.id, MODULE_COLOR_PALETTE[index % MODULE_COLOR_PALETTE.length]);
+    });
+    return map;
+  }, [modules]);
+
+  const statusAdjustmentMap = useMemo(() => {
+    const map = new Map();
+    statuses.forEach((status, index) => {
+      const adjustment = STATUS_SHADE_STEPS[index % STATUS_SHADE_STEPS.length];
+      map.set(status, adjustment);
+    });
+    return map;
+  }, [statuses]);
+
+  const fallbackStatus = statuses.length > 0 ? statuses[statuses.length - 1] : '';
+
+  const baseStatusData = useMemo(() => {
+    const counts = statuses.map((status) => ({
+      key: status,
+      label: status,
+      status,
+      value: 0,
+      color: STATUS_COLORS[status] || '#94a3b8'
+    }));
+
+    tasks.forEach((task) => {
+      const status = statuses.includes(task.status) ? task.status : fallbackStatus;
+      const target = counts.find((item) => item.status === status);
+      if (target) {
+        target.value += 1;
+      }
+    });
+    return counts;
+  }, [fallbackStatus, statuses, tasks]);
+
+  const { chartData, legendEntries, totalTasks } = useMemo(() => {
+    if (!moduleDistinctionEnabled || modules.length <= 1) {
+      const total = baseStatusData.reduce((acc, item) => acc + item.value, 0);
+      const formatted = baseStatusData.map((item) => ({
+        ...item,
+        percentage: total === 0 ? '0%' : `${((item.value / total) * 100).toFixed(1).replace(/\.0$/, '')}%`
+      }));
+      return {
+        chartData: formatted.filter((item) => item.value > 0),
+        legendEntries: formatted,
+        totalTasks: total
+      };
+    }
+
+    const moduleStatusCounts = new Map();
+    tasks.forEach((task) => {
+      const normalizedStatus = statuses.includes(task.status) ? task.status : fallbackStatus;
+      if (!normalizedStatus) return;
+      const key = `${task.moduleId}-${normalizedStatus}`;
+      moduleStatusCounts.set(key, (moduleStatusCounts.get(key) || 0) + 1);
+    });
+
+    const entries = [];
+    const legend = [];
+    let total = 0;
+    modules.forEach((module, moduleIndex) => {
+      const baseColor = moduleColorMap.get(module.id) || MODULE_COLOR_PALETTE[moduleIndex % MODULE_COLOR_PALETTE.length];
+      statuses.forEach((status, statusIndex) => {
+        const statusCount = moduleStatusCounts.get(`${module.id}-${status}`) || 0;
+        const adjustment = statusAdjustmentMap.get(status) ?? STATUS_SHADE_STEPS[statusIndex % STATUS_SHADE_STEPS.length];
+        const color = adjustColor(baseColor, adjustment);
+        const label = `${module.name} · ${status}`;
+        legend.push({
+          key: `${module.id}-${status}`,
+          label,
+          value: statusCount,
+          color,
+          percentage: 0
+        });
+        total += statusCount;
+        if (statusCount > 0) {
+          entries.push({
+            key: `${module.id}-${status}`,
+            label,
+            value: statusCount,
+            color,
+            percentage: '0%'
+          });
+        }
+      });
+    });
+
+    const formattedEntries = entries.map((item) => ({
+      ...item,
+      percentage: total === 0 ? '0%' : `${((item.value / total) * 100).toFixed(1).replace(/\.0$/, '')}%`
+    }));
+
+    const formattedLegend = legend.map((item) => ({
+      ...item,
+      percentage: total === 0 ? '0%' : `${((item.value / total) * 100).toFixed(1).replace(/\.0$/, '')}%`
+    }));
+
+    return {
+      chartData: formattedEntries,
+      legendEntries: formattedLegend,
+      totalTasks: total
+    };
+  }, [
+    baseStatusData,
+    moduleDistinctionEnabled,
+    moduleColorMap,
+    modules,
+    statusAdjustmentMap,
+    statuses,
+    tasks,
+    fallbackStatus
+  ]);
+
+  const toggleDisabled = modules.length <= 1;
+
+  return (
+    <section className="card dashboard-card">
+      <div className="dashboard-header">
+        <div className="dashboard-title-group">
+          <h2>项目任务仪表盘</h2>
+          <p className="dashboard-subtitle">
+            {project ? `项目“${project.name}”的任务状态分布` : '请选择项目以查看任务状态概览'}
+          </p>
+        </div>
+        <label className="dashboard-toggle">
+          <input
+            type="checkbox"
+            checked={moduleDistinctionEnabled}
+            onChange={(event) => onModuleDistinctionChange?.(event.target.checked)}
+            disabled={toggleDisabled}
+            title={toggleDisabled ? '至少需要 2 个模块才能区分显示' : undefined}
+          />
+          <span>在饼图中区分模块</span>
+        </label>
+      </div>
+      <div className="dashboard-body">
+        <div className="dashboard-chart-container">
+          <div className="dashboard-chart">
+            <PieChart data={chartData} />
+            {totalTasks > 0 ? (
+              <div className="dashboard-chart-center">
+                <span className="dashboard-chart-total">{totalTasks}</span>
+                <span className="dashboard-chart-label">任务总数</span>
+              </div>
+            ) : null}
+          </div>
+        </div>
+        <ul className="dashboard-legend" aria-label="任务状态图例">
+          {legendEntries.map((item) => (
+            <li key={item.key} className="dashboard-legend-item">
+              <span className="dashboard-legend-color" style={{ backgroundColor: item.color }} />
+              <div className="dashboard-legend-text">
+                <span className="dashboard-legend-label">{item.label}</span>
+                <span className="dashboard-legend-value">
+                  {item.value} {item.percentage !== '0%' ? `(${item.percentage})` : ''}
+                </span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+};
+
+export default Dashboard;

--- a/src/styles.css
+++ b/src/styles.css
@@ -70,6 +70,163 @@ body {
   gap: 16px;
 }
 
+.dashboard-card {
+  gap: 16px;
+}
+
+.dashboard-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.dashboard-title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.dashboard-subtitle {
+  margin: 0;
+  font-size: 13px;
+  color: #64748b;
+}
+
+.dashboard-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: #475569;
+}
+
+.dashboard-toggle input {
+  width: 18px;
+  height: 18px;
+  accent-color: #2563eb;
+}
+
+.dashboard-toggle input:disabled {
+  cursor: not-allowed;
+}
+
+.dashboard-toggle input:disabled + span {
+  color: #94a3b8;
+}
+
+.dashboard-body {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+  align-items: center;
+}
+
+.dashboard-chart-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.dashboard-chart {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 260px;
+  height: 260px;
+}
+
+.dashboard-chart-svg {
+  width: 100%;
+  height: 100%;
+}
+
+.dashboard-chart-center {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  pointer-events: none;
+}
+
+.dashboard-chart-total {
+  font-size: 28px;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.dashboard-chart-label {
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.dashboard-chart-empty {
+  width: 240px;
+  height: 240px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #f1f5f9;
+  color: #64748b;
+  font-size: 13px;
+  text-align: center;
+  padding: 24px;
+}
+
+.dashboard-legend {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.dashboard-legend-item {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.dashboard-legend-color {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.dashboard-legend-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.dashboard-legend-label {
+  font-size: 13px;
+  color: #1f2937;
+}
+
+.dashboard-legend-value {
+  font-size: 12px;
+  color: #64748b;
+}
+
+@media (max-width: 600px) {
+  .dashboard-body {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard-chart {
+    width: 220px;
+    height: 220px;
+  }
+}
+
 .selection-toolbar {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- add a dashboard component that renders a pie chart of project task statuses and optionally distinguishes modules
- compute project-level task aggregates and integrate the dashboard into the main workspace
- style the dashboard, legend, and toggle to match the existing layout

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e682d2af98833083159080f931e11c