### PR TITLE
Fix pie chart rendering for single slice

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -104,6 +104,23 @@ const PieChart = ({ data, size = 240 }) => {
         const startAngle = currentAngle;
         const endAngle = startAngle + sliceAngle;
         currentAngle = endAngle;
+
+        if (sliceAngle >= Math.PI * 2 - 1e-6) {
+          return (
+            <circle
+              key={item.key}
+              cx={center}
+              cy={center}
+              r={radius}
+              fill={item.color}
+              stroke="#ffffff"
+              strokeWidth={1.5}
+            >
+              <title>{`${item.label}: ${item.value} (${item.percentage})`}</title>
+            </circle>
+          );
+        }
+
         return (
           <path
             key={item.key}


### PR DESCRIPTION
## Summary
- render a full circle slice as an SVG circle to avoid zero-area paths
- ensure the pie chart remains visible when one status contains all tasks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e71935e6408330b556efb1768c509a