### PR TITLE
Display stage tasks as header remarks

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -726,6 +726,23 @@ body {
   font-weight: 600;
 }
 
+.stage-header-content {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.stage-header-title {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.stage-header-remark {
+  font-size: 12px;
+  font-weight: 400;
+  color: #334155;
+}
+
 .task-name-cell {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- show stage template guidance as a remark alongside each stage header instead of adding placeholder rows
- allow tasks to change their stage while editing and expose all available stages in the selector
- add styling for the new stage remark text in the task table header

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e71c58c8108330b32c05819d06948c