### PR TITLE
Fix task stage updates and add deletion support

### DIFF
--- a/backend/src/main/kotlin/com/example/flowtask/api/FlowDataController.kt
+++ b/backend/src/main/kotlin/com/example/flowtask/api/FlowDataController.kt
@@ -2,6 +2,7 @@ package com.example.flowtask.api
 
 import com.example.flowtask.service.FlowDataService
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -130,7 +131,16 @@ class FlowDataController(private val flowDataService: FlowDataService) {
     @PutMapping("/tasks/{id}")
     fun updateTask(@PathVariable id: String, @RequestBody request: TaskUpdateRequest): Task {
         validateTaskPayload(null, request.stageId, request.name, request.priority, request.status)
+        if (request.parentTaskId != null && request.parentStageTaskId != null) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Task cannot have both parent task and parent stage task")
+        }
         return flowDataService.updateTask(id, request)
+    }
+
+    @DeleteMapping("/tasks/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun deleteTask(@PathVariable id: String) {
+        flowDataService.deleteTask(id)
     }
 
     private fun validateTaskPayload(

--- a/backend/src/main/kotlin/com/example/flowtask/api/FlowDataModels.kt
+++ b/backend/src/main/kotlin/com/example/flowtask/api/FlowDataModels.kt
@@ -125,5 +125,7 @@ data class TaskUpdateRequest(
     val priority: String,
     val status: String,
     val startDate: String?,
-    val endDate: String?
+    val endDate: String?,
+    val parentTaskId: String?,
+    val parentStageTaskId: String?
 )

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -566,6 +566,19 @@ export default function App() {
     }
   };
 
+  const handleDeleteTask = async (taskId) => {
+    try {
+      const targetTask = tasks.find((task) => task.id === taskId);
+      await requestJson(`/api/tasks/${taskId}`, {
+        method: 'DELETE'
+      });
+      const moduleInfo = targetTask ? modules.find((module) => module.id === targetTask.moduleId) : null;
+      await loadData({ projectId: moduleInfo?.projectId, moduleId: targetTask?.moduleId });
+    } catch (deleteError) {
+      setError(deleteError instanceof Error ? deleteError.message : '删除任务失败');
+    }
+  };
+
   const stageOptions = stages;
 
   return (
@@ -882,6 +895,7 @@ export default function App() {
                 tasks={tasks.filter((task) => task.moduleId === selectedModule.id)}
                 onAddTask={handleAddTask}
                 onUpdateTask={handleUpdateTask}
+                onDeleteTask={handleDeleteTask}
                 priorities={PRIORITIES}
                 statuses={STATUSES}
               />

--- a/src/components/ModuleView.jsx
+++ b/src/components/ModuleView.jsx
@@ -31,6 +31,7 @@ const ModuleView = ({
   tasks,
   onAddTask,
   onUpdateTask,
+  onDeleteTask,
   priorities,
   statuses
 }) => {
@@ -353,7 +354,9 @@ const ModuleView = ({
         priority: payload.priority,
         status: payload.status,
         startDate: payload.startDate,
-        endDate: payload.endDate
+        endDate: payload.endDate,
+        parentTaskId: dialogState.parentTaskId,
+        parentStageTaskId: dialogState.parentStageTaskId
       });
     }
 
@@ -475,6 +478,17 @@ const ModuleView = ({
                                 onClick={() => openCreateSubtaskDialog(node)}
                               >
                                 添加子任务
+                              </button>
+                              <button
+                                type="button"
+                                className="danger-action"
+                                onClick={() => {
+                                  if (window.confirm('确定要删除该任务及其子任务吗？')) {
+                                    onDeleteTask(node.id);
+                                  }
+                                }}
+                              >
+                                删除
                               </button>
                             </div>
                           )}

--- a/src/styles.css
+++ b/src/styles.css
@@ -487,6 +487,16 @@ body {
   font-size: 13px;
 }
 
+.table-actions .danger-action {
+  background-color: #fee2e2;
+  color: #b91c1c;
+}
+
+.table-actions .danger-action:hover {
+  background-color: #fecaca;
+  color: #991b1b;
+}
+
 .secondary {
   background-color: #e2e8f0 !important;
   color: #475569 !important;


### PR DESCRIPTION
## Summary
- ensure task update requests carry parent references and validate stage template assignments so that tasks appear under the correct workflow stage
- add backend delete task support with cascading removal of child tasks and expose it through the REST controller
- update the frontend to send parent linkage changes, surface a task delete action, and style the destructive button

## Testing
- `npm run build`
- `mvn -f backend test` *(fails: unable to download Spring Boot parent POM – Maven Central returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e72046e9448330872ba082dce9e0b3