### PR TITLE
Enable project-level tasks and enhance dashboard filters

### DIFF
--- a/backend/src/main/kotlin/com/example/flowtask/api/FlowDataController.kt
+++ b/backend/src/main/kotlin/com/example/flowtask/api/FlowDataController.kt
@@ -121,7 +121,14 @@ class FlowDataController(private val flowDataService: FlowDataService) {
 
     @PostMapping("/tasks")
     fun createTask(@RequestBody request: TaskCreateRequest): Task {
-        validateTaskPayload(request.moduleId, request.stageId, request.name, request.priority, request.status)
+        validateTaskPayload(
+            request.projectId,
+            request.moduleId,
+            request.stageId,
+            request.name,
+            request.priority,
+            request.status
+        )
         if (request.parentTaskId != null && request.parentStageTaskId != null) {
             throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Task cannot have both parent task and parent stage task")
         }
@@ -130,7 +137,7 @@ class FlowDataController(private val flowDataService: FlowDataService) {
 
     @PutMapping("/tasks/{id}")
     fun updateTask(@PathVariable id: String, @RequestBody request: TaskUpdateRequest): Task {
-        validateTaskPayload(null, request.stageId, request.name, request.priority, request.status)
+        validateTaskPayload(null, null, request.stageId, request.name, request.priority, request.status)
         if (request.parentTaskId != null && request.parentStageTaskId != null) {
             throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Task cannot have both parent task and parent stage task")
         }
@@ -144,12 +151,16 @@ class FlowDataController(private val flowDataService: FlowDataService) {
     }
 
     private fun validateTaskPayload(
+        projectId: String?,
         moduleId: String?,
         stageId: String?,
         name: String?,
         priority: String?,
         status: String?
     ) {
+        if (projectId != null && projectId.isBlank()) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Project is required")
+        }
         if (moduleId != null && moduleId.isBlank()) {
             throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Module is required")
         }

--- a/backend/src/main/kotlin/com/example/flowtask/api/FlowDataModels.kt
+++ b/backend/src/main/kotlin/com/example/flowtask/api/FlowDataModels.kt
@@ -47,7 +47,8 @@ data class Module(
 
 data class Task(
     val id: String,
-    val moduleId: String,
+    val projectId: String,
+    val moduleId: String?,
     val stageId: String,
     val taskTypeId: String?,
     val name: String,
@@ -104,7 +105,8 @@ data class ModuleRequest(
 )
 
 data class TaskCreateRequest(
-    val moduleId: String,
+    val projectId: String,
+    val moduleId: String?,
     val stageId: String,
     val taskTypeId: String?,
     val name: String,

--- a/backend/src/main/resources/db/migration/V2__tasks_project_optional_module.sql
+++ b/backend/src/main/resources/db/migration/V2__tasks_project_optional_module.sql
@@ -1,0 +1,10 @@
+ALTER TABLE tasks DROP CONSTRAINT IF EXISTS fk_task_module;
+ALTER TABLE tasks ADD COLUMN project_id VARCHAR(64);
+UPDATE tasks t
+SET project_id = m.project_id
+FROM modules m
+WHERE t.module_id = m.id;
+ALTER TABLE tasks ALTER COLUMN project_id SET NOT NULL;
+ALTER TABLE tasks ADD CONSTRAINT fk_task_project FOREIGN KEY (project_id) REFERENCES projects(id);
+ALTER TABLE tasks ALTER COLUMN module_id DROP NOT NULL;
+ALTER TABLE tasks ADD CONSTRAINT fk_task_module FOREIGN KEY (module_id) REFERENCES modules(id) ON DELETE SET NULL;

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 const STATUS_COLORS = {
   未开始: '#94a3b8',
@@ -18,6 +18,13 @@ const MODULE_COLOR_PALETTE = [
 ];
 
 const STATUS_SHADE_STEPS = [-0.18, 0.02, 0.18, 0.3];
+const GROUPING_FIELDS = [
+  { key: 'stage', label: '阶段' },
+  { key: 'taskType', label: '任务类型' },
+  { key: 'priority', label: '优先级' },
+  { key: 'status', label: '状态' }
+];
+const UNASSIGNED_MODULE_KEY = '__unassigned__';
 
 const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
 
@@ -75,12 +82,28 @@ const describeSlice = (cx, cy, radius, startAngle, endAngle) => {
   ].join(' ');
 };
 
+const getTextColor = (hex) => {
+  if (!hex) return '#0f172a';
+  let normalized = hex.replace('#', '');
+  if (normalized.length === 3) {
+    normalized = normalized
+      .split('')
+      .map((char) => char + char)
+      .join('');
+  }
+  const num = parseInt(normalized, 16);
+  if (Number.isNaN(num)) return '#0f172a';
+  const r = (num >> 16) & 0xff;
+  const g = (num >> 8) & 0xff;
+  const b = num & 0xff;
+  const luminance = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
+  return luminance > 0.6 ? '#0f172a' : '#f8fafc';
+};
+
 const PieChart = ({ data, size = 240 }) => {
   const total = data.reduce((acc, item) => acc + item.value, 0);
   if (total === 0) {
-    return (
-      <div className="dashboard-chart-empty">暂无可用的任务数据</div>
-    );
+    return <div className="dashboard-chart-empty">暂无可用的任务数据</div>;
   }
 
   const radius = size / 2;
@@ -103,34 +126,61 @@ const PieChart = ({ data, size = 240 }) => {
         const sliceAngle = (item.value / total) * Math.PI * 2;
         const startAngle = currentAngle;
         const endAngle = startAngle + sliceAngle;
+        const midAngle = startAngle + sliceAngle / 2;
         currentAngle = endAngle;
+
+        const labelRadius = radius * 0.65;
+        const labelX = center + labelRadius * Math.cos(midAngle);
+        const labelY = center + labelRadius * Math.sin(midAngle);
 
         if (sliceAngle >= Math.PI * 2 - 1e-6) {
           return (
-            <circle
-              key={item.key}
-              cx={center}
-              cy={center}
-              r={radius}
+            <g key={item.key}>
+              <circle
+                cx={center}
+                cy={center}
+                r={radius}
+                fill={item.color}
+                stroke="#ffffff"
+                strokeWidth={1.5}
+              >
+                <title>{`${item.label}: ${item.value} (${item.percentage})`}</title>
+              </circle>
+              <text
+                x={center}
+                y={center}
+                textAnchor="middle"
+                dominantBaseline="middle"
+                fill={getTextColor(item.color)}
+                fontSize={14}
+              >
+                {item.value}
+              </text>
+            </g>
+          );
+        }
+
+        return (
+          <g key={item.key}>
+            <path
+              d={describeSlice(center, center, radius, startAngle, endAngle)}
               fill={item.color}
               stroke="#ffffff"
               strokeWidth={1.5}
             >
               <title>{`${item.label}: ${item.value} (${item.percentage})`}</title>
-            </circle>
-          );
-        }
-
-        return (
-          <path
-            key={item.key}
-            d={describeSlice(center, center, radius, startAngle, endAngle)}
-            fill={item.color}
-            stroke="#ffffff"
-            strokeWidth={1.5}
-          >
-            <title>{`${item.label}: ${item.value} (${item.percentage})`}</title>
-          </path>
+            </path>
+            <text
+              x={labelX}
+              y={labelY}
+              textAnchor="middle"
+              dominantBaseline="middle"
+              fill={getTextColor(item.color)}
+              fontSize={14}
+            >
+              {item.value}
+            </text>
+          </g>
         );
       })}
     </svg>
@@ -142,126 +192,216 @@ const Dashboard = ({
   tasks,
   modules,
   statuses,
+  stages,
+  taskTypes,
+  priorities,
   moduleDistinctionEnabled,
   onModuleDistinctionChange
 }) => {
+  const moduleLabelMap = useMemo(() => {
+    const map = new Map();
+    modules.forEach((module) => {
+      map.set(module.id, module.name);
+    });
+    map.set(UNASSIGNED_MODULE_KEY, '未分配模块');
+    return map;
+  }, [modules]);
+
   const moduleColorMap = useMemo(() => {
     const map = new Map();
     modules.forEach((module, index) => {
       map.set(module.id, MODULE_COLOR_PALETTE[index % MODULE_COLOR_PALETTE.length]);
     });
+    const unassignedIndex = modules.length % MODULE_COLOR_PALETTE.length;
+    map.set(UNASSIGNED_MODULE_KEY, MODULE_COLOR_PALETTE[unassignedIndex]);
     return map;
   }, [modules]);
 
-  const statusAdjustmentMap = useMemo(() => {
-    const map = new Map();
-    statuses.forEach((status, index) => {
-      const adjustment = STATUS_SHADE_STEPS[index % STATUS_SHADE_STEPS.length];
-      map.set(status, adjustment);
+  const moduleOptions = useMemo(() => {
+    const options = modules.map((module) => ({ id: module.id, label: module.name }));
+    const hasUnassigned = tasks.some((task) => !task.moduleId);
+    if (hasUnassigned) {
+      options.push({ id: UNASSIGNED_MODULE_KEY, label: moduleLabelMap.get(UNASSIGNED_MODULE_KEY) });
+    }
+    return options;
+  }, [modules, tasks, moduleLabelMap]);
+
+  const [selectedModuleIds, setSelectedModuleIds] = useState(() => moduleOptions.map((option) => option.id));
+
+  useEffect(() => {
+    const optionIds = moduleOptions.map((option) => option.id);
+    setSelectedModuleIds((prev) => {
+      const filtered = prev.filter((id) => optionIds.includes(id));
+      const selectedSet = new Set(filtered);
+      const ordered = optionIds.filter((id) => selectedSet.has(id));
+      const missing = optionIds.filter((id) => !selectedSet.has(id));
+      const next = [...ordered, ...missing];
+      if (next.length === 0) {
+        return optionIds;
+      }
+      if (next.length === prev.length && next.every((id, index) => id === prev[index])) {
+        return prev;
+      }
+      return next;
     });
-    return map;
-  }, [statuses]);
+  }, [moduleOptions]);
 
-  const fallbackStatus = statuses.length > 0 ? statuses[statuses.length - 1] : '';
+  const [selectedGroupFields, setSelectedGroupFields] = useState(['status']);
 
-  const baseStatusData = useMemo(() => {
-    const counts = statuses.map((status) => ({
-      key: status,
-      label: status,
-      status,
-      value: 0,
-      color: STATUS_COLORS[status] || '#94a3b8'
-    }));
+  const stageNameMap = useMemo(() => new Map(stages.map((stage) => [stage.id, stage.name])), [stages]);
+  const taskTypeNameMap = useMemo(
+    () => new Map(taskTypes.map((taskType) => [taskType.id, taskType.name])),
+    [taskTypes]
+  );
+  const groupLabelMap = useMemo(
+    () => new Map(GROUPING_FIELDS.map((item) => [item.key, item.label])),
+    []
+  );
 
-    tasks.forEach((task) => {
-      const status = statuses.includes(task.status) ? task.status : fallbackStatus;
-      const target = counts.find((item) => item.status === status);
-      if (target) {
-        target.value += 1;
+  const allowModuleDistinction = selectedModuleIds.filter(Boolean).length > 1;
+
+  useEffect(() => {
+    if (moduleDistinctionEnabled && !allowModuleDistinction) {
+      onModuleDistinctionChange?.(false);
+    }
+  }, [allowModuleDistinction, moduleDistinctionEnabled, onModuleDistinctionChange]);
+
+  const moduleDimensionEnabled = moduleDistinctionEnabled && allowModuleDistinction;
+
+  const filteredTasks = useMemo(() => {
+    if (selectedModuleIds.length === 0) {
+      return [];
+    }
+    const selectedSet = new Set(selectedModuleIds);
+    return tasks.filter((task) => selectedSet.has(task.moduleId ?? UNASSIGNED_MODULE_KEY));
+  }, [selectedModuleIds, tasks]);
+
+  const groupingFields = selectedGroupFields.length > 0 ? selectedGroupFields : ['status'];
+
+  const baseEntries = useMemo(() => {
+    if (filteredTasks.length === 0) {
+      return [];
+    }
+    const combos = new Map();
+    filteredTasks.forEach((task) => {
+      const moduleKey = task.moduleId ?? UNASSIGNED_MODULE_KEY;
+      const values = {};
+      const labelParts = [];
+
+      if (moduleDimensionEnabled) {
+        labelParts.push(`模块：${moduleLabelMap.get(moduleKey) || '未分配模块'}`);
+      }
+
+      groupingFields.forEach((field) => {
+        let entry;
+        if (field === 'stage') {
+          const stageId = task.stageId || '__no_stage__';
+          const label = stageNameMap.get(task.stageId) || (task.stageId ? `未知阶段(${task.stageId})` : '未指定阶段');
+          entry = { key: stageId, label };
+        } else if (field === 'taskType') {
+          const typeId = task.taskTypeId || '__no_task_type__';
+          const label = task.taskTypeId
+            ? taskTypeNameMap.get(task.taskTypeId) || `未知类型(${task.taskTypeId})`
+            : '未指定类型';
+          entry = { key: typeId, label };
+        } else if (field === 'priority') {
+          const priorityValue = task.priority || '';
+          const label = priorityValue || '未设置优先级';
+          entry = { key: priorityValue || '__no_priority__', label };
+        } else if (field === 'status') {
+          const statusValue = task.status || '';
+          const label = statusValue || '未设置状态';
+          entry = { key: statusValue || '__no_status__', label };
+        } else {
+          entry = { key: 'unknown', label: '未知' };
+        }
+        values[field] = entry;
+        const fieldLabel = groupLabelMap.get(field) || field;
+        labelParts.push(`${fieldLabel}：${entry.label}`);
+      });
+
+      const keyParts = [];
+      if (moduleDimensionEnabled) {
+        keyParts.push(moduleKey);
+      }
+      groupingFields.forEach((field) => {
+        keyParts.push(values[field]?.key ?? '__unset__');
+      });
+      const mapKey = keyParts.join('|');
+      const current = combos.get(mapKey);
+      if (current) {
+        current.value += 1;
+      } else {
+        combos.set(mapKey, {
+          key: mapKey,
+          moduleKey: moduleDimensionEnabled ? moduleKey : null,
+          values,
+          labelParts,
+          value: 1
+        });
       }
     });
-    return counts;
-  }, [fallbackStatus, statuses, tasks]);
-
-  const { chartData, legendEntries, totalTasks } = useMemo(() => {
-    if (!moduleDistinctionEnabled || modules.length <= 1) {
-      const total = baseStatusData.reduce((acc, item) => acc + item.value, 0);
-      const formatted = baseStatusData.map((item) => ({
-        ...item,
-        percentage: total === 0 ? '0%' : `${((item.value / total) * 100).toFixed(1).replace(/\.0$/, '')}%`
-      }));
-      return {
-        chartData: formatted.filter((item) => item.value > 0),
-        legendEntries: formatted,
-        totalTasks: total
-      };
-    }
-
-    const moduleStatusCounts = new Map();
-    tasks.forEach((task) => {
-      const normalizedStatus = statuses.includes(task.status) ? task.status : fallbackStatus;
-      if (!normalizedStatus) return;
-      const key = `${task.moduleId}-${normalizedStatus}`;
-      moduleStatusCounts.set(key, (moduleStatusCounts.get(key) || 0) + 1);
-    });
-
-    const entries = [];
-    const legend = [];
-    let total = 0;
-    modules.forEach((module, moduleIndex) => {
-      const baseColor = moduleColorMap.get(module.id) || MODULE_COLOR_PALETTE[moduleIndex % MODULE_COLOR_PALETTE.length];
-      statuses.forEach((status, statusIndex) => {
-        const statusCount = moduleStatusCounts.get(`${module.id}-${status}`) || 0;
-        const adjustment = statusAdjustmentMap.get(status) ?? STATUS_SHADE_STEPS[statusIndex % STATUS_SHADE_STEPS.length];
-        const color = adjustColor(baseColor, adjustment);
-        const label = `${module.name} · ${status}`;
-        legend.push({
-          key: `${module.id}-${status}`,
-          label,
-          value: statusCount,
-          color,
-          percentage: 0
-        });
-        total += statusCount;
-        if (statusCount > 0) {
-          entries.push({
-            key: `${module.id}-${status}`,
-            label,
-            value: statusCount,
-            color,
-            percentage: '0%'
-          });
-        }
-      });
-    });
-
-    const formattedEntries = entries.map((item) => ({
+    const entries = Array.from(combos.values()).map((item) => ({
       ...item,
-      percentage: total === 0 ? '0%' : `${((item.value / total) * 100).toFixed(1).replace(/\.0$/, '')}%`
+      label: item.labelParts.join(' / ')
     }));
-
-    const formattedLegend = legend.map((item) => ({
-      ...item,
-      percentage: total === 0 ? '0%' : `${((item.value / total) * 100).toFixed(1).replace(/\.0$/, '')}%`
-    }));
-
-    return {
-      chartData: formattedEntries,
-      legendEntries: formattedLegend,
-      totalTasks: total
-    };
+    entries.sort((a, b) => a.label.localeCompare(b.label, 'zh-CN'));
+    return entries;
   }, [
-    baseStatusData,
-    moduleDistinctionEnabled,
-    moduleColorMap,
-    modules,
-    statusAdjustmentMap,
-    statuses,
-    tasks,
-    fallbackStatus
+    filteredTasks,
+    moduleDimensionEnabled,
+    moduleLabelMap,
+    groupingFields,
+    groupLabelMap,
+    stageNameMap,
+    taskTypeNameMap
   ]);
 
-  const toggleDisabled = modules.length <= 1;
+  const coloredEntries = useMemo(() => {
+    const moduleCounters = new Map();
+    let paletteIndex = 0;
+    return baseEntries.map((entry) => {
+      let color;
+      if (moduleDimensionEnabled) {
+        const moduleKey = entry.moduleKey ?? UNASSIGNED_MODULE_KEY;
+        const baseColor = moduleColorMap.get(moduleKey) || MODULE_COLOR_PALETTE[0];
+        const count = moduleCounters.get(moduleKey) || 0;
+        const adjustment = STATUS_SHADE_STEPS[count % STATUS_SHADE_STEPS.length];
+        moduleCounters.set(moduleKey, count + 1);
+        color = adjustColor(baseColor, adjustment);
+      } else if (groupingFields.length === 1 && groupingFields[0] === 'status') {
+        const statusKey = entry.values.status?.key || '';
+        color = STATUS_COLORS[statusKey] || '#94a3b8';
+      } else {
+        color = MODULE_COLOR_PALETTE[paletteIndex % MODULE_COLOR_PALETTE.length];
+        paletteIndex += 1;
+      }
+      return { ...entry, color };
+    });
+  }, [baseEntries, moduleDimensionEnabled, moduleColorMap, groupingFields]);
+
+  const totalTasks = filteredTasks.length;
+
+  const legendEntries = useMemo(
+    () =>
+      coloredEntries.map((entry) => ({
+        ...entry,
+        percentage:
+          totalTasks === 0
+            ? '0%'
+            : `${((entry.value / totalTasks) * 100)
+                .toFixed(1)
+                .replace(/\.0$/, '')}%`
+      })),
+    [coloredEntries, totalTasks]
+  );
+
+  const chartData = useMemo(
+    () => legendEntries.filter((entry) => entry.value > 0),
+    [legendEntries]
+  );
+
+  const toggleDisabled = !allowModuleDistinction;
 
   return (
     <section className="card dashboard-card">
@@ -269,20 +409,88 @@ const Dashboard = ({
         <div className="dashboard-title-group">
           <h2>项目任务仪表盘</h2>
           <p className="dashboard-subtitle">
-            {project ? `项目“${project.name}”的任务状态分布` : '请选择项目以查看任务状态概览'}
+            {project ? `项目“${project.name}”的任务分布概览` : '请选择项目以查看任务概览'}
           </p>
         </div>
         <label className="dashboard-toggle">
           <input
             type="checkbox"
-            checked={moduleDistinctionEnabled}
+            checked={moduleDistinctionEnabled && !toggleDisabled}
             onChange={(event) => onModuleDistinctionChange?.(event.target.checked)}
             disabled={toggleDisabled}
-            title={toggleDisabled ? '至少需要 2 个模块才能区分显示' : undefined}
+            title={toggleDisabled ? '至少需要 2 个已选模块才能区分显示' : undefined}
           />
           <span>在饼图中区分模块</span>
         </label>
       </div>
+
+      <div className="dashboard-controls">
+        <div className="dashboard-filter-group">
+          <div className="dashboard-filter-title">模块筛选</div>
+          {moduleOptions.length > 0 ? (
+            <div className="dashboard-checkbox-grid">
+              {moduleOptions.map((option) => {
+                const checked = selectedModuleIds.includes(option.id);
+                return (
+                  <label key={option.id}>
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={(event) => {
+                        const { checked: isChecked } = event.target;
+                        setSelectedModuleIds((prev) => {
+                          if (isChecked) {
+                            if (prev.includes(option.id)) return prev;
+                            return [...prev, option.id];
+                          }
+                          if (prev.length <= 1) {
+                            return prev;
+                          }
+                          const next = prev.filter((id) => id !== option.id);
+                          return next.length === 0 ? prev : next;
+                        });
+                      }}
+                    />
+                    {option.label}
+                  </label>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="dashboard-filter-empty">暂无模块可筛选</div>
+          )}
+        </div>
+
+        <div className="dashboard-filter-group">
+          <div className="dashboard-filter-title">饼图维度</div>
+          <div className="dashboard-checkbox-grid">
+            {GROUPING_FIELDS.map((field) => {
+              const checked = selectedGroupFields.includes(field.key);
+              return (
+                <label key={field.key}>
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={(event) => {
+                      const { checked: isChecked } = event.target;
+                      setSelectedGroupFields((prev) => {
+                        if (isChecked) {
+                          if (prev.includes(field.key)) return prev;
+                          return [...prev, field.key];
+                        }
+                        return prev.filter((item) => item !== field.key);
+                      });
+                    }}
+                  />
+                  {field.label}
+                </label>
+              );
+            })}
+          </div>
+          <p className="dashboard-filter-hint">未选择维度时将按状态统计</p>
+        </div>
+      </div>
+
       <div className="dashboard-body">
         <div className="dashboard-chart-container">
           <div className="dashboard-chart">
@@ -307,6 +515,11 @@ const Dashboard = ({
               </div>
             </li>
           ))}
+          {legendEntries.length === 0 ? (
+            <li className="dashboard-legend-item muted">
+              <span className="dashboard-legend-text">暂无匹配的任务</span>
+            </li>
+          ) : null}
         </ul>
       </div>
     </section>

--- a/src/components/ModuleView.jsx
+++ b/src/components/ModuleView.jsx
@@ -210,7 +210,7 @@ const ModuleView = ({
       taskId: null,
       form: { ...emptyForm }
     });
-  }, [emptyForm, module.id, workflow.id]);
+  }, [emptyForm, module?.id, workflow.id]);
 
   const stageGroups = useMemo(() => {
     const stageIdSet = new Set(stageOrder);
@@ -329,7 +329,8 @@ const ModuleView = ({
 
     const normalizedTaskTypeId = dialogState.form.taskTypeId ? dialogState.form.taskTypeId : null;
     const payload = {
-      moduleId: module.id,
+      projectId: project.id,
+      moduleId: module?.id ?? null,
       stageId: dialogState.form.stageId,
       taskTypeId: normalizedTaskTypeId,
       name: dialogState.form.name.trim(),

--- a/src/styles.css
+++ b/src/styles.css
@@ -123,6 +123,64 @@ body {
   align-items: center;
 }
 
+.dashboard-controls {
+  display: grid;
+  gap: 16px;
+  padding: 12px 16px;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  background: #f8fafc;
+}
+
+@media (min-width: 720px) {
+  .dashboard-controls {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+}
+
+.dashboard-filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dashboard-filter-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.dashboard-checkbox-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 8px;
+}
+
+.dashboard-checkbox-grid label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: #334155;
+}
+
+.dashboard-checkbox-grid input {
+  width: 16px;
+  height: 16px;
+  accent-color: #2563eb;
+}
+
+.dashboard-filter-empty {
+  font-size: 12px;
+  color: #94a3b8;
+}
+
+.dashboard-filter-hint {
+  margin: 0;
+  font-size: 12px;
+  color: #94a3b8;
+}
+
 .dashboard-chart-container {
   display: flex;
   justify-content: center;
@@ -191,6 +249,11 @@ body {
   display: flex;
   gap: 10px;
   align-items: center;
+}
+
+.dashboard-legend-item.muted {
+  color: #94a3b8;
+  font-size: 13px;
 }
 
 .dashboard-legend-color {


### PR DESCRIPTION
## Summary
- allow tasks to be created without a module by adding project tracking to tasks and API validation
- update the dashboard to support module filtering, multi-dimension grouping, and inline slice counts
- surface project-level tasks in the UI with a dedicated selection option and styling tweaks

## Testing
- pnpm run build
- mvn test *(fails: unable to download Spring Boot parent POM due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e722b2a2c48330b7b2e1530b9edccc