### PR TITLE
Handle missing workflow assignments on projects

### DIFF
--- a/backend/src/main/kotlin/com/example/flowtask/api/FlowDataModels.kt
+++ b/backend/src/main/kotlin/com/example/flowtask/api/FlowDataModels.kt
@@ -35,7 +35,7 @@ data class Workflow(
 data class Project(
     val id: String,
     val name: String,
-    val workflowId: String
+    val workflowId: String?
 )
 
 data class Module(

--- a/backend/src/main/kotlin/com/example/flowtask/service/FlowDataService.kt
+++ b/backend/src/main/kotlin/com/example/flowtask/service/FlowDataService.kt
@@ -124,7 +124,7 @@ class FlowDataService(private val jdbcTemplate: NamedParameterJdbcTemplate) {
             Project(
                 id = rs.getString("id"),
                 name = rs.getString("name"),
-                workflowId = rs.getString("workflow_id")
+                workflowId = rs.getString("workflow_id")?.takeIf { it.isNotBlank() }
             )
         }
     }
@@ -354,7 +354,7 @@ class FlowDataService(private val jdbcTemplate: NamedParameterJdbcTemplate) {
                 .addValue("name", request.name.trim())
                 .addValue("workflowId", request.workflowId)
         )
-        return Project(id, request.name.trim(), request.workflowId)
+        return Project(id, request.name.trim(), request.workflowId.trim())
     }
 
     @Transactional
@@ -369,7 +369,7 @@ class FlowDataService(private val jdbcTemplate: NamedParameterJdbcTemplate) {
         if (rows == 0) {
             throw EmptyResultDataAccessException(1)
         }
-        return Project(id, request.name.trim(), request.workflowId)
+        return Project(id, request.name.trim(), request.workflowId.trim())
     }
 
     @Transactional


### PR DESCRIPTION
## Summary
- allow project DTOs to surface a null workflow reference instead of crashing when the database contains missing data
- trim workflow identifiers when creating or updating projects

## Testing
- mvn -q -DskipTests package *(fails: unable to download spring-boot-starter-parent 3.5.4 from Maven Central due to HTTP 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e72b5525248330bfcb6c261d60940f