### PR TITLE
Add work log filtering and display for tasks

### DIFF
--- a/backend/src/main/kotlin/com/example/flowtask/api/FlowDataModels.kt
+++ b/backend/src/main/kotlin/com/example/flowtask/api/FlowDataModels.kt
@@ -58,7 +58,15 @@ data class Task(
     val startDate: String?,
     val endDate: String?,
     val parentTaskId: String?,
-    val parentStageTaskId: String?
+    val parentStageTaskId: String?,
+    val workLogs: List<TaskWorkLog> = emptyList()
+)
+
+data class TaskWorkLog(
+    val id: String,
+    val taskId: String,
+    val workTime: String,
+    val content: String
 )
 
 data class FlowDataResponse(

--- a/backend/src/main/resources/db/migration/V6__create_task_work_logs.sql
+++ b/backend/src/main/resources/db/migration/V6__create_task_work_logs.sql
@@ -1,0 +1,10 @@
+CREATE TABLE task_work_logs (
+    id VARCHAR(64) PRIMARY KEY,
+    task_id VARCHAR(64) NOT NULL,
+    work_time TIMESTAMP NOT NULL,
+    content TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_task_work_logs_task FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_task_work_logs_task_time ON task_work_logs(task_id, work_time);

--- a/src/styles.css
+++ b/src/styles.css
@@ -749,6 +749,41 @@ body {
   align-self: flex-end;
 }
 
+.task-filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: flex-end;
+  margin-bottom: 16px;
+}
+
+.task-filter-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.task-filter-field span {
+  font-size: 12px;
+  color: #475569;
+}
+
+.task-filter-field input,
+.task-filter-field select {
+  height: 36px;
+  min-width: 180px;
+}
+
+.task-filter-actions {
+  display: flex;
+  align-items: flex-end;
+}
+
+.task-filter-actions button {
+  height: 36px;
+  padding: 0 16px;
+}
+
 .task-table-container {
   border: 1px solid #e2e8f0;
   border-radius: 12px;
@@ -820,6 +855,12 @@ body {
   display: flex;
   flex-direction: column;
   gap: 4px;
+}
+
+.task-work-cell {
+  max-width: 360px;
+  white-space: normal;
+  color: #334155;
 }
 
 .task-name-title {


### PR DESCRIPTION
## Summary
- add a Flyway migration to store per-task work log entries with timestamps and content
- expose work logs through the task API models and service methods
- surface work log details and a time-based filter bar in the module task table UI with supporting styles

## Testing
- `npm run build`
- `mvn -f backend/pom.xml test` *(fails: unable to download spring-boot-starter-parent due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e72ea171f08330960985de167ffafc