### PR TITLE
Add task module selection and work log editing support

### DIFF
--- a/backend/src/main/kotlin/com/example/flowtask/api/FlowDataController.kt
+++ b/backend/src/main/kotlin/com/example/flowtask/api/FlowDataController.kt
@@ -132,15 +132,17 @@ class FlowDataController(private val flowDataService: FlowDataService) {
         if (request.parentTaskId != null && request.parentStageTaskId != null) {
             throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Task cannot have both parent task and parent stage task")
         }
+        validateWorkLogs(request.workLogs)
         return flowDataService.createTask(request)
     }
 
     @PutMapping("/tasks/{id}")
     fun updateTask(@PathVariable id: String, @RequestBody request: TaskUpdateRequest): Task {
-        validateTaskPayload(null, null, request.stageId, request.name, request.priority, request.status)
+        validateTaskPayload(null, request.moduleId, request.stageId, request.name, request.priority, request.status)
         if (request.parentTaskId != null && request.parentStageTaskId != null) {
             throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Task cannot have both parent task and parent stage task")
         }
+        validateWorkLogs(request.workLogs)
         return flowDataService.updateTask(id, request)
     }
 
@@ -175,6 +177,17 @@ class FlowDataController(private val flowDataService: FlowDataService) {
         }
         if (status == null || status.isBlank()) {
             throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Task status is required")
+        }
+    }
+
+    private fun validateWorkLogs(logs: List<TaskWorkLogRequest>) {
+        logs.forEach { log ->
+            if (log.workTime.isBlank()) {
+                throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Work log time is required")
+            }
+            if (log.content.isBlank()) {
+                throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Work log content is required")
+            }
         }
     }
 

--- a/backend/src/main/kotlin/com/example/flowtask/api/FlowDataModels.kt
+++ b/backend/src/main/kotlin/com/example/flowtask/api/FlowDataModels.kt
@@ -69,6 +69,11 @@ data class TaskWorkLog(
     val content: String
 )
 
+data class TaskWorkLogRequest(
+    val workTime: String,
+    val content: String
+)
+
 data class FlowDataResponse(
     val stages: List<Stage>,
     val taskTypes: List<TaskType>,
@@ -124,10 +129,12 @@ data class TaskCreateRequest(
     val startDate: String?,
     val endDate: String?,
     val parentTaskId: String?,
-    val parentStageTaskId: String?
+    val parentStageTaskId: String?,
+    val workLogs: List<TaskWorkLogRequest> = emptyList()
 )
 
 data class TaskUpdateRequest(
+    val moduleId: String?,
     val stageId: String,
     val taskTypeId: String?,
     val name: String,
@@ -137,5 +144,6 @@ data class TaskUpdateRequest(
     val startDate: String?,
     val endDate: String?,
     val parentTaskId: String?,
-    val parentStageTaskId: String?
+    val parentStageTaskId: String?,
+    val workLogs: List<TaskWorkLogRequest> = emptyList()
 )

--- a/backend/src/main/kotlin/com/example/flowtask/service/FlowDataService.kt
+++ b/backend/src/main/kotlin/com/example/flowtask/service/FlowDataService.kt
@@ -7,7 +7,10 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.jdbc.core.namedparam.SqlParameterSource
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.sql.Timestamp
 import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
 import java.util.UUID
 
@@ -437,7 +440,9 @@ class FlowDataService(private val jdbcTemplate: NamedParameterJdbcTemplate) {
             throw IllegalArgumentException("Project not found")
         }
 
-        request.moduleId?.let { moduleId ->
+        val normalizedModuleId = request.moduleId?.takeIf { it.isNotBlank() }
+
+        normalizedModuleId?.let { moduleId ->
             val moduleProjectId = jdbcTemplate.query(
                 "SELECT project_id FROM modules WHERE id = :id",
                 mapOf("id" to moduleId)
@@ -452,7 +457,7 @@ class FlowDataService(private val jdbcTemplate: NamedParameterJdbcTemplate) {
         val params = MapSqlParameterSource()
             .addValue("id", id)
             .addValue("projectId", request.projectId)
-            .addValue("moduleId", request.moduleId)
+            .addValue("moduleId", normalizedModuleId)
             .addValue("stageId", request.stageId)
             .addValue("taskTypeId", request.taskTypeId)
             .addValue("name", request.name.trim())
@@ -470,6 +475,7 @@ class FlowDataService(private val jdbcTemplate: NamedParameterJdbcTemplate) {
             """.trimIndent(),
             params
         )
+        saveTaskWorkLogs(id, request.workLogs)
         return findTaskById(id)
     }
 
@@ -478,6 +484,9 @@ class FlowDataService(private val jdbcTemplate: NamedParameterJdbcTemplate) {
         if (request.parentTaskId != null && request.parentStageTaskId != null) {
             throw IllegalArgumentException("Task cannot have both parent task and parent stage task")
         }
+
+        val existingTask = findTaskById(id)
+        val normalizedModuleId = request.moduleId?.takeIf { it.isNotBlank() }
 
         request.parentStageTaskId?.let { parentStageTaskId ->
             val parentStageId = jdbcTemplate.query(
@@ -492,10 +501,22 @@ class FlowDataService(private val jdbcTemplate: NamedParameterJdbcTemplate) {
             }
         }
 
+        normalizedModuleId?.let { moduleId ->
+            val moduleProjectId = jdbcTemplate.query(
+                "SELECT project_id FROM modules WHERE id = :id",
+                mapOf("id" to moduleId)
+            ) { rs, _ -> rs.getString("project_id") }
+                .firstOrNull() ?: throw IllegalArgumentException("Module not found")
+            if (moduleProjectId != existingTask.projectId) {
+                throw IllegalArgumentException("Module does not belong to the task project")
+            }
+        }
+
         val rows = jdbcTemplate.update(
             """
                 UPDATE tasks
-                SET stage_id = :stageId,
+                SET module_id = :moduleId,
+                    stage_id = :stageId,
                     task_type_id = :taskTypeId,
                     name = :name,
                     description = :description,
@@ -509,6 +530,7 @@ class FlowDataService(private val jdbcTemplate: NamedParameterJdbcTemplate) {
             """.trimIndent(),
             MapSqlParameterSource()
                 .addValue("id", id)
+                .addValue("moduleId", normalizedModuleId)
                 .addValue("stageId", request.stageId)
                 .addValue("taskTypeId", request.taskTypeId)
                 .addValue("name", request.name.trim())
@@ -523,6 +545,7 @@ class FlowDataService(private val jdbcTemplate: NamedParameterJdbcTemplate) {
         if (rows == 0) {
             throw EmptyResultDataAccessException(1)
         }
+        saveTaskWorkLogs(id, request.workLogs)
         return findTaskById(id)
     }
 
@@ -590,6 +613,66 @@ class FlowDataService(private val jdbcTemplate: NamedParameterJdbcTemplate) {
             LocalDate.parse(value)
         } catch (ex: DateTimeParseException) {
             throw IllegalArgumentException("Invalid date format: $value", ex)
+        }
+    }
+
+    private fun parseDateTime(value: String): LocalDateTime {
+        val normalized = value.trim().ifEmpty {
+            throw IllegalArgumentException("Work log time is required")
+        }
+        val candidate = normalized.replace(' ', 'T')
+        val formatters = listOf(
+            DateTimeFormatter.ISO_LOCAL_DATE_TIME,
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm")
+        )
+        formatters.forEach { formatter ->
+            try {
+                return LocalDateTime.parse(candidate, formatter)
+            } catch (_: DateTimeParseException) {
+                // try next formatter
+            }
+        }
+        if (candidate.length >= 10) {
+            return try {
+                LocalDate.parse(candidate.substring(0, 10)).atStartOfDay()
+            } catch (ex: Exception) {
+                throw IllegalArgumentException("Invalid date format: $value", ex)
+            }
+        }
+        throw IllegalArgumentException("Invalid date format: $value")
+    }
+
+    private fun saveTaskWorkLogs(taskId: String, logs: List<TaskWorkLogRequest>) {
+        jdbcTemplate.update(
+            "DELETE FROM task_work_logs WHERE task_id = :taskId",
+            mapOf("taskId" to taskId)
+        )
+        if (logs.isEmpty()) {
+            return
+        }
+
+        val sql = """
+            INSERT INTO task_work_logs(id, task_id, work_time, content)
+            VALUES (:id, :taskId, :workTime, :content)
+        """.trimIndent()
+
+        logs.mapNotNull { log ->
+            val trimmedContent = log.content.trim()
+            if (trimmedContent.isEmpty()) {
+                null
+            } else {
+                val workTime = parseDateTime(log.workTime)
+                Triple(UUID.randomUUID().toString(), Timestamp.valueOf(workTime), trimmedContent)
+            }
+        }.forEach { (id, workTime, content) ->
+            jdbcTemplate.update(
+                sql,
+                MapSqlParameterSource()
+                    .addValue("id", id)
+                    .addValue("taskId", taskId)
+                    .addValue("workTime", workTime)
+                    .addValue("content", content)
+            )
         }
     }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1008,6 +1008,37 @@ body {
   min-height: 96px;
 }
 
+.worklog-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.worklog-row {
+  display: grid;
+  grid-template-columns: minmax(0, 200px) 1fr auto;
+  gap: 8px;
+  align-items: start;
+}
+
+.worklog-row input {
+  width: 100%;
+}
+
+.worklog-row textarea {
+  min-height: 72px;
+  resize: vertical;
+}
+
+.worklog-remove-button {
+  align-self: center;
+  white-space: nowrap;
+}
+
+.worklog-add-button {
+  align-self: flex-start;
+}
+
 .dialog-field--wide {
   grid-column: 1 / -1;
 }


### PR DESCRIPTION
## Summary
- allow updating task modules and work logs via the API, including new request payloads and persistence helpers
- expose an “All modules” view on the task page with a module column, module selector, and work log editor in the task dialog
- style the new work log editor controls

## Testing
- pnpm run build
- mvn -q test *(fails: Maven Central blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e731ce17f48330ba81d45f0b9ddddc