### PR TITLE
Combine module and dimension filters in dashboard

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -124,30 +124,13 @@ body {
 }
 
 .dashboard-controls {
-  display: grid;
-  gap: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
   padding: 12px 16px;
   border: 1px solid #e2e8f0;
   border-radius: 10px;
   background: #f8fafc;
-}
-
-@media (min-width: 720px) {
-  .dashboard-controls {
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  }
-}
-
-.dashboard-filter-group {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.dashboard-filter-title {
-  font-size: 13px;
-  font-weight: 600;
-  color: #1e293b;
 }
 
 .dashboard-filter-tree {
@@ -197,6 +180,13 @@ body {
   flex: 1;
 }
 
+.dashboard-tree-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: #1e293b;
+  flex: 1;
+}
+
 .dashboard-tree-parent input {
   width: 16px;
   height: 16px;
@@ -239,31 +229,6 @@ body {
   font-size: 12px;
   color: #94a3b8;
   padding: 4px 0;
-}
-
-.dashboard-checkbox-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 8px;
-}
-
-.dashboard-checkbox-grid label {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 13px;
-  color: #334155;
-}
-
-.dashboard-checkbox-grid input {
-  width: 16px;
-  height: 16px;
-  accent-color: #2563eb;
-}
-
-.dashboard-filter-empty {
-  font-size: 12px;
-  color: #94a3b8;
 }
 
 .dashboard-filter-hint {


### PR DESCRIPTION
## Summary
- merge the module selection and pie chart dimension controls into a single tree-style panel
- add expand/collapse behavior and select-all support to the module filter for consistency
- update dashboard styles to reflect the unified filter layout

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7524595ec8330a1d13313b03ce450